### PR TITLE
bflb: add BL60x BLE controller and PHY/RF binary blobs and headers

### DIFF
--- a/include/bouffalolab/bl60x/ble/ble_lib_api.h
+++ b/include/bouffalolab/bl60x/ble/ble_lib_api.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016-2023 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef BLE_LIB_API_H_
+#define BLE_LIB_API_H_
+
+void ble_controller_init(uint8_t task_priority);
+void ble_controller_deinit(void);
+#if !defined(CONFIG_FREERTOS) && !defined(CONFIG_AOS) && !defined(CONFIG_NUTTX)
+void blecontroller_main(void);
+#endif
+#if defined(CONFIG_BT_RESET)
+void ble_controller_reset(void);
+#endif
+char *ble_controller_get_lib_ver(void);
+
+/* if 0, success.
+ * if -1, fail,
+ */
+int8_t ble_controller_set_scan_filter_table_size(uint8_t size);
+
+/* return sleep duration, in unit of 1/32768s
+ * if 0, means not allow sleep
+ * if -1, means allow sleep, but there is no end of sleep interrupt
+ *        (ble core deep sleep is not enabled)
+ */
+int32_t ble_controller_sleep(int32_t max_sleep_cycles);
+void ble_controller_sleep_restore(void);
+bool ble_controller_sleep_is_ongoing(void);
+void ble_controller_set_tx_pwr(int ble_tx_power);
+int8_t ble_controller_get_tx_pwr(void);
+void ble_rf_set_tx_channel(uint16_t tx_channel);
+void ble_controller_disable_adv_random_delay(bool disable);
+
+#if defined(CONFIG_BLE_MFG)
+#define BLE_TEST_TX	0x00
+#define BLE_TEST_RX	0x01
+#define BLE_TEST_RXTX	0x02
+#define BLE_TEST_END	0x03
+
+/* HCI LE Receiver Test Command parameters structure */
+struct le_rx_test_cmd {
+	uint8_t rx_freq;
+};
+
+/* HCI LE Transmitter Test Command parameters structure */
+struct le_tx_test_cmd {
+	uint8_t tx_freq;
+	uint8_t test_data_len;
+	uint8_t pk_payload_type;
+};
+
+struct le_enhanced_rx_test_cmd {
+	uint8_t rx_freq;
+	uint8_t rx_phy;
+	uint8_t modulation_index;
+};
+
+/* HCI LE Enhanced Transmitter Test Command parameters structure */
+struct le_enhanced_tx_test_cmd {
+	uint8_t tx_freq;
+	uint8_t test_data_len;
+	uint8_t pk_payload_type;
+	uint8_t tx_phy;
+};
+
+int le_rx_test_cmd_handler(uint16_t src_id, void *param, bool from_hci);
+int le_tx_test_cmd_handler(uint16_t src_id, void *param, bool from_hci);
+int le_test_end_cmd_handler(bool from_hci);
+uint8_t le_get_direct_test_type(void);
+void le_test_mode_custom_aa(uint32_t access_code);
+
+#if defined(CONFIG_BLE_MFG_HCI_CMD)
+int reset_cmd_handler(void);
+#endif
+#endif
+
+/* ble controller debug level */
+#define BT_SCHEDULE_DEBUG_MASK	0x00000001
+#define BT_MEM_DEBUG_MASK	0x00000002
+
+void ble_controller_set_debug_level(uint32_t debug_level);
+void ble_controller_trace_malloc_init(void *buffer, uint32_t size);
+
+#endif /* BLE_LIB_API_H_ */

--- a/include/bouffalolab/bl60x/ble/hci_onchip.h
+++ b/include/bouffalolab/bl60x/ble/hci_onchip.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2023 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef HCI_ONCHIP_H_
+#define HCI_ONCHIP_H_
+
+enum {
+	BT_HCI_CMD,
+	BT_HCI_ACL_DATA,
+	BT_HCI_CMD_CMP_EVT,
+	BT_HCI_CMD_STAT_EVT,
+	BT_HCI_LE_EVT,
+	BT_HCI_EVT,
+};
+
+typedef struct {
+	uint16_t opcode;
+	uint8_t *params;
+	uint8_t param_len;
+} bl_hci_cmd_struct;
+
+typedef struct {
+	uint16_t conhdl;
+	uint8_t pb_bc_flag;
+	uint16_t len;
+	uint8_t *buffer;
+} bl_hci_acl_data_tx;
+
+typedef struct {
+	union {
+		bl_hci_cmd_struct hci_cmd;
+		bl_hci_acl_data_tx acl_data;
+	} p;
+} hci_pkt_struct;
+
+typedef void (*bt_hci_recv_cb)(uint8_t pkt_type, uint16_t src_id,
+			       uint8_t *param, uint8_t param_len);
+
+uint8_t bt_onchiphci_interface_init(bt_hci_recv_cb cb);
+int8_t bt_onchiphci_send(uint8_t pkt_type, uint16_t dest_id,
+			 hci_pkt_struct *pkt);
+uint8_t bt_onchiphci_handle_rx_acl(void *param, uint8_t *host_buf_data);
+
+#endif /* HCI_ONCHIP_H_ */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -224,3 +224,28 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "PHY/RF library for BL616"
     doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/drivers/soc/bl616/phyrf
+# BL60x series
+  - path: lib/bl60x/libblecontroller_bl602_m1s1.a
+    sha256: d0d535ffc52fc342d33ddf8db56088c9d2df8734a6c0ea08951bb3dea143fa28
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/blecontroller/lib/libblecontroller_bl602_m1s1.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BLE controller library for BL602 (variant: m1s1, 1 central + 1 peripheral)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/blecontroller
+  - path: lib/bl60x/libblecontroller_bl602_m8s1.a
+    sha256: f529783ae35620ba9f7da02ac9dd5cec3542f5019e9c991c07f2662c5e89edac
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/blecontroller/lib/libblecontroller_bl602_m8s1.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BLE controller library for BL602 (variant: m8s1, 8 central + 1 peripheral)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/blecontroller
+  - path: lib/bl60x/libbl602_phyrf.a
+    sha256: 1040009fa1cdfca6627a241a49bb33107775ca1b979b3b4153d76f6daf2859fd
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/drivers/soc/bl602/phyrf/lib-gcc-10.2.0-rv32imfc-ilp32f-bouffalosdk/libbl602_phyrf.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "PHY/RF library for BL602 (BL60x)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/drivers/soc/bl602/phyrf


### PR DESCRIPTION
Add minimum required headers and blob declarations for BL602 BLE controller support.

All blobs sourced from `bouffalo_sdk` commit `ad2a37b8`.