### PR TITLE
bflb: add BL61x BLE controller and PHY/RF binary blobs and headers

### DIFF
--- a/include/bouffalolab/bl61x/ble/btble_lib_api.h
+++ b/include/bouffalolab/bl61x/ble/btble_lib_api.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2016-2026 Bouffalolab.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef BLE_LIB_API_H_
+#define BLE_LIB_API_H_
+
+struct btblecontroller_resource_conf {
+	// The size of bluetooth EM area
+	uint32_t em_size;
+	// If allocate resource for ble observer. If CONFIG_BT_OBSERVER is
+	// enabled, shall allocate this resource. Otherwise, not allocate.
+	// 1:allocate, 0:not allocate.
+	uint8_t ble_observer;
+	// If allocate resource for ble central. If CONFIG_BT_CENTRAL is
+	// enabled, shall allocate this resource. Otherwise, not allocate.
+	// 1:allocate, 0:not allocate.
+	uint8_t ble_central;
+	// If allocate resource for ble extended adv.  If CONFIG_ADV_EXTENSION
+	// is enabled, shall allocate this resource. Otherwise, not allocate.
+	// 1:allocate, 0:not allocate.
+	uint8_t ble_ext_adv;
+	// Number of max activities
+	uint8_t ble_activity_max;
+	// Number of max ble links
+	uint8_t ble_conn_max;
+	// Maximum number of devices in resolving address list
+	uint8_t ble_ral_max;
+	// Number of RX descriptors
+	uint8_t ble_rx_desc_nb;
+	// Number of TX data buffer
+	uint8_t ble_acl_buf_nb_tx;
+};
+
+// This API is only used in ble only mode without iso/cte to configure ble
+// resource when CONFIG_BLE_RES_DYNAMIC_CONF is enabled and shall be called
+// before btble_controller_init.
+void btble_controller_resource_config(
+	struct btblecontroller_resource_conf *conf);
+
+// Set stack size of btblecontroller task before btble_controller_init if upper
+// layer wants to modify the stack size. The default stack size of
+// btblecontroller task is 2k in ble only mode and 4k in bt/ble mode.
+void btble_controller_set_task_stack_size(uint16_t stack_size);
+void btble_controller_init(uint8_t task_priority);
+#if defined(CONFIG_NUTTX)
+void btblecontroller_main(void *pvParameters);
+#endif
+// API for different RTOS porting to handle btbelcontroller task's messages.
+void btblecontroller_proc(void *data);
+
+void btble_controller_deinit(void);
+int32_t btble_controller_sleep(int32_t max_sleep_cycles);
+void btble_controller_sleep_restore();
+
+#define BTBLE_IN_ACTIVE_STATE         0
+#define BTBLE_IN_SLEEP_STATE          1
+#define BTBLE_IN_WAKEUP_ONGOING_STATE 2
+// The return value is an instantaneous state that may change rapidly.
+uint8_t btble_controller_get_state(void);
+
+void btble_controller_reset(void);
+
+/**
+ * @brief BLE event priority configuration limits
+ */
+#define BLE_EVENT_PRIORITY_MIN 0  /**< Minimum priority value */
+#define BLE_EVENT_PRIORITY_MAX 15 /**< Maximum priority value */
+#define BLE_EVENT_PRIORITY_INVALID                                             \
+	0xFFFFFFFF /**< Invalid priority return value */
+/**
+ * @brief BLE event types for priority configuration
+ */
+#define BLE_EVENT_CONNECT_IND_TX_RX                                            \
+	0 /**< Connection indication transmission/reception on primary         \
+	     advertising channels */
+#define BLE_EVENT_LLCP_MESSAGE 1 /**< LLCP BLE messages */
+#define BLE_EVENT_DATA_CHANNEL_TX                                              \
+	2 /**< Data channel transmission BLE messages */
+#define BLE_EVENT_INITIATING_SCANNING                                          \
+	3 /**< Initiating/Extended initiating (scanning) on primary            \
+	     advertising channels */
+#define BLE_EVENT_ACTIVE_SCANNING                                              \
+	4 /**< Active scanning/Extended active scanning on primary advertising \
+	     channels */
+#define BLE_EVENT_CONNECTABLE_ADV                                              \
+	5 /**< Connectable advertising/Extended advertising on primary         \
+	     advertising channels */
+#define BLE_EVENT_NON_CONNECTABLE_ADV                                          \
+	6 /**< Non-connectable advertising/Extended advertising on primary     \
+	     advertising channels */
+#define BLE_EVENT_PASSIVE_SCANNING                                             \
+	7 /**< Passive scanning/Extended passive scanning on primary           \
+	     advertising channels */
+/**
+ * @brief Get the priority of a specific BLE event
+ *
+ * @param event The BLE event type to get priority for
+ * @return uint32_t Event priority value (0-15) or 0xFFFFFFFF if event is
+ * invalid
+ *
+ * @note This function returns the current real-time priority value for the
+ * specified event type. The returned value may differ from the previously set
+ * priority due to the controller's internal scheduling mechanism. Higher values
+ * indicate higher priority.
+ */
+uint32_t btble_controller_get_event_priority(uint8_t event);
+/**
+ * @brief Set the priority for a specific BLE event
+ *
+ * @param event The BLE event type to set priority for
+ * @param priority Priority value to set (0-15, where 15 is highest priority)
+ * @return int 0 on success, -1 if event or priority is invalid
+ *
+ * @note This function configures the priority for the specified event type in
+ * the controller. The set priority value may be modified by the controller's
+ * internal scheduling mechanism to optimize overall system performance.
+ */
+int btble_controller_set_event_priority(uint8_t event, uint8_t priority);
+
+/* key: 32 bytes ecdh private key. This key shall be malloced and passed to
+ * btblecontroller_set_private_key api, and when encrypt is done shall call
+ * btblecontroller_del_private_key to delete key and then free malloced key.*/
+void btblecontroller_set_private_key(uint8_t *key);
+uint8_t *btblecontroller_del_private_key(void);
+
+char *btble_controller_get_lib_ver(void);
+
+void btble_controller_remaining_mem(uint8_t **addr, int *size);
+
+void btble_controller_set_cs2(uint8_t enable); // cs2 is enabled by default
+
+void btble_controller_set_local_sdk_ver(uint32_t sdk_ver);
+
+#if defined(BL702L)
+void btble_controller_sleep_init(void);
+typedef int (*btble_before_sleep_cb_t)(void);
+typedef void (*btble_after_sleep_cb_t)(void);
+typedef void (*btble_sleep_aborted_cb_t)(void);
+int8_t btble_controller_get_tx_pwr(void);
+void btble_set_before_sleep_callback(btble_before_sleep_cb_t cb);
+void btble_set_after_sleep_callback(btble_after_sleep_cb_t cb);
+/*
+  If ble sleep preparation is aborted before sleep, this callback will be
+  trigerred. Please be noticed, this callback is triggerd after
+  before_sleep_callback. e.g. Application disables something before sleep,
+  application needs to enable these when sleep is aborted.
+*/
+void btble_set_sleep_aborted_callback(btble_sleep_aborted_cb_t cb);
+#endif
+
+// sco/esco callback to codec
+typedef void (*bt_sco_codec_cb_t)(uint16_t interval_halfslot,
+				  uint32_t tx_buffer_0, uint32_t tx_buffer_1,
+				  uint32_t rx_buffer_0, uint32_t rx_buffer_1,
+				  uint32_t tx_buffer_size,
+				  uint32_t rx_buffer_size,
+				  uint32_t start_time_halfslot,
+				  uint8_t buffer_index);
+void btble_controller_sco_codec_callback_register(bt_sco_codec_cb_t cb);
+
+#endif

--- a/include/bouffalolab/bl61x/ble/btblecontroller_port.h
+++ b/include/bouffalolab/bl61x/ble/btblecontroller_port.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2026 Bouffalolab.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef BTBLECONTROLLER_PORT_API_H_
+#define BTBLECONTROLLER_PORT_API_H_
+
+void btblecontroller_ble_irq_init(void *handler);
+void btblecontroller_bt_irq_init(void *handler);
+void btblecontroller_dm_irq_init(void *handler);
+void btblecontroller_ble_irq_enable(uint8_t enable);
+void btblecontroller_bt_irq_enable(uint8_t enable);
+void btblecontroller_dm_irq_enable(uint8_t enable);
+void btblecontroller_enable_ble_clk(uint8_t enable);
+void btblecontroller_rf_restore(void);
+int btblecontroller_efuse_read_mac(uint8_t mac[6]);
+void btblecontroller_software_btdm_reset(void);
+void btblecontroller_software_pds_reset(void);
+void btblecontroller_pds_trim_rc32m(void);
+uint8_t btblecontrolller_get_chip_version(void);
+void btblecontroller_sys_reset(void);
+int btblecontroller_putchar(int c);
+void btblecontroller_puts(const char *str);
+
+#endif /* BTBLECONTROLLER_PORT_API_H_ */

--- a/include/bouffalolab/bl61x/ble/hci_onchip.h
+++ b/include/bouffalolab/bl61x/ble/hci_onchip.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2026 Bouffalolab.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef HCI_ONCHIP_H_
+#define HCI_ONCHIP_H_
+
+enum{
+    BT_HCI_CMD,
+    BT_HCI_ACL_DATA,
+    BT_HCI_CMD_CMP_EVT,
+    BT_HCI_CMD_STAT_EVT,
+    BT_HCI_LE_EVT,
+    BT_HCI_EVT,
+    BT_HCI_SYNC_DATA,
+    BT_HCI_DBG_EVT,
+};
+
+typedef struct{
+    uint16_t opcode;
+    uint8_t *params;
+    uint8_t param_len;
+    #if defined(CONFIG_BT_MFG_HCI_CMD)
+    bool from_hci;
+    #endif
+}bl_hci_cmd_struct;
+
+typedef struct {
+    /// connection handle
+    uint16_t    conhdl;
+    /// broadcast and packet boundary flag
+    uint8_t     pb_bc_flag;
+    /// length of the data
+    uint16_t    len;
+    uint8_t* buffer;
+}bl_hci_acl_data_tx;
+
+typedef struct{
+    union{
+        bl_hci_cmd_struct hci_cmd;
+        bl_hci_acl_data_tx acl_data;
+    }p;
+}hci_pkt_struct;
+
+typedef void (*bt_hci_recv_cb)(uint8_t pkt_type, uint16_t src_id, uint8_t *param, uint8_t param_len);
+
+uint8_t bt_onchiphci_interface_init(bt_hci_recv_cb cb);
+int8_t bt_onchiphci_send(uint8_t pkt_type, uint16_t dest_id, hci_pkt_struct *pkt);
+uint16_t bt_onchiphci_handle_rx_acl(void *param, uint8_t *host_buf_data);
+
+#endif

--- a/include/bouffalolab/bl61x/wl_api.h
+++ b/include/bouffalolab/bl61x/wl_api.h
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2016-2026 Bouffalolab.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __WL_API_H__
+#define __WL_API_H__
+
+/**
+ * WL_API_RMEM_EN and WL_API_RMEM_ADDR
+ *
+ * WL_API_RMEM_EN:
+ * - Can't be set to 0 (compile error if you do)
+ * - Must be enabled for consistent behavior across modules
+ *
+ * WL_API_RMEM_ADDR:
+ * - You don't have to use this - pick any address you want - Pass it to wl_cfg_get() via rmem parameter
+ * - Config goes through APIs/structs, not compile options
+ */
+#if defined(WL_API_RMEM_EN) && (WL_API_RMEM_EN == 0)
+    #error "WL_API_RMEM_EN cannot be defined to 0"
+#elif !defined(WL_API_RMEM_EN)
+    #define WL_API_RMEM_EN (1)
+#endif
+
+#if defined(WL_API_RMEM_EN) && WL_API_RMEM_EN
+    #ifndef WL_API_RMEM_ADDR
+    #define WL_API_RMEM_ADDR 0x20010600
+    #endif
+#endif
+
+#define NUM_WLAN_CHANNELS           (14)
+#define NUM_BZ_CH_PWRCOMP           (5)
+
+enum
+{
+    WL_API_MODE_WLAN = 1,
+    WL_API_MODE_BZ = 2,
+    WL_API_MODE_ALL = 3
+};
+
+enum
+{
+    WL_API_STATUS_OK = 0,
+    WL_API_STATUS_INITED = 0xacde,
+};
+
+enum
+{
+    WL_WLAN_MODE_NON_HT = 0,
+    WL_WLAN_MODE_NON_HT_DUP_OFDM,
+    WL_WLAN_MODE_HT_MF,
+    WL_WLAN_MODE_HT_GF,
+    WL_WLAN_MODE_VHT,
+    WL_WLAN_MODE_HE_SU,
+    WL_WLAN_MODE_HE_MU,
+    WL_WLAN_MODE_HE_ER,
+    WL_WLAN_MODE_MAX
+};
+
+enum
+{
+    WL_BZ_MODE_802154 = 0,
+    WL_BZ_MODE_BLE,
+    WL_BZ_MODE_BT_BR,
+    WL_BZ_MODE_BT_EDR,
+    WL_BZ_MODE_MAX
+};
+
+enum wl_xtalfreq_enum
+{
+    WL_XTAL_24M = 0,
+    WL_XTAL_26M,
+    WL_XTAL_32M,
+    WL_XTAL_38M4,
+    WL_XTAL_40M,
+    WL_XTAL_52M,
+    WL_NUM_XTAL
+};
+
+enum
+{
+    WL_ENV_LP_ACQ  = 0,
+    WL_ENV_LP_TRK = 1,
+};
+
+
+struct wl_param_tcal_t
+{
+    uint8_t     en_tcal;
+    uint8_t     linear_or_follow;
+    uint16_t    Tchannels[5];
+    int16_t     Tchannel_os[5];
+    int16_t     Tchannel_os_low[5];
+    int16_t     Troom_os;
+};
+
+struct wl_param_pwrcal_t
+{
+    int8_t      channel_pwrcomp_wlan[NUM_WLAN_CHANNELS];
+    int8_t      channel_lp_pwrcomp_wlan[NUM_WLAN_CHANNELS]; // power compensation at low power mode
+    int8_t      Temperature_MP; // temperature of sensor while power cal at production line
+    int8_t      channel_pwrcomp_bz[NUM_BZ_CH_PWRCOMP];
+};
+
+// Power vs Rate table in 0.25dBm
+struct wl_param_pwrtarget_t
+{
+    int8_t     pwr_11b[4];
+    int8_t     pwr_11g[8];
+    int8_t     pwr_11n_ht20[8];
+    int8_t     pwr_11n_ht40[8];
+    int8_t     pwr_11ac_vht20[10];
+    int8_t     pwr_11ac_vht40[10];
+    int8_t     pwr_11ac_vht80[10];
+    int8_t     pwr_11ax_he20[12];
+    int8_t     pwr_11ax_he40[12];
+    int8_t     pwr_11ax_he80[12];
+    int8_t     pwr_11ax_he160[12];
+    int8_t     pwr_ble;
+    int8_t     pwr_bt[3];
+    int8_t     pwr_zigbee;
+};
+
+// Maximum power limit table in 1dB for different regulations (SRRC/FCC/CE...)
+struct wl_param_pwrlimit_t
+{
+    uint8_t en;    // enable power limit
+    int8_t b_dsss; // power limit for 11b 1/2Mbps
+    int8_t b_cck;  // power limit for 11b 5.5/11Mbps
+    int8_t g;      // power limit for 11g
+    int8_t n20;    // power limit for 11n 20M BW
+    int8_t ax20;   // power limit for 11ax 20M BW
+    int8_t n40;    // power limit for 11n 40M BW
+    int8_t ax40;   // power limit for 11ax 40M BW
+};
+
+struct wl_efuse_t
+{
+    uint8_t     device_info;
+    uint8_t     chip_version;
+    uint8_t     iptat_code;
+    uint8_t     icx_code;
+    uint8_t     dcdc_vout_trim_aon;
+    int8_t      Temperature_MP; // temperature of Tsensor while power cal at production line
+};
+
+struct wl_param_tcap_t
+{
+    uint8_t     en_tcap;
+    int8_t      tcap_tsen[10];
+    int8_t      tcap_cap[11];
+};
+
+struct wl_param_spur_rules_t
+{
+    uint32_t    cfg20;
+    uint32_t    cfg40;
+};
+
+struct wl_param_t
+{
+    uint32_t                     xtalfreq_hz;     // multi source driven (efuse/flash/dts...)
+    uint8_t                      xtalcapcode_in;  // multi source driven (efuse/flash/dts...)
+    uint8_t                      xtalcapcode_out; // multi source driven (efuse/flash/dts...)
+    uint16_t                     country_code;    // multi source driven (efuse/flash/dts...)
+    struct wl_param_tcal_t       tcal;            // multi source driven (efuse/flash/dts...)
+    struct wl_param_pwrtarget_t  pwrtarget;       // multi source driven (efuse/flash/dts...)
+    struct wl_param_pwrcal_t     pwrcal;          // multi source driven (efuse/flash/dts...)
+    struct wl_param_pwrlimit_t   pwrlim[NUM_WLAN_CHANNELS];
+    struct wl_efuse_t            ef;
+    struct wl_param_tcap_t       tcap;
+    struct wl_param_spur_rules_t spur_rules[NUM_WLAN_CHANNELS];
+    uint8_t                      spur_rules_en[NUM_WLAN_CHANNELS];
+    uint8_t                      bz_backoff_db[21];
+};
+
+struct wl_env_t
+{
+    int8_t   lp_bcn_rssi;
+    uint16_t lp_bcn_lost_cnt;
+    uint32_t lp_bcn_time_us;
+    uint8_t  lp_gain_mode;
+    uint8_t  lp_status;
+};
+
+typedef enum
+{
+    WL_DEVICE_QFN40 = 0,
+    WL_DEVICE_QFN40M,
+    WL_DEVICE_QFN56
+} wl_device_info_t;
+
+typedef enum
+{
+    WL_LOG_LEVEL_NONE = 0, // No logging
+    WL_LOG_LEVEL_CRITICAL, // Critical messages such as cli cmd response
+    WL_LOG_LEVEL_TRACE,    // Trace activities
+    WL_LOG_LEVEL_ERROR,    // Error conditions
+    WL_LOG_LEVEL_WARN,     // Warning conditions
+    WL_LOG_LEVEL_INFO,     // Informational messages
+    WL_LOG_LEVEL_DEBUG,    // Debug messages
+} wl_log_level_t;
+
+/**
+ * @struct wl_cfg_t
+ * @brief WL CFG structure containing function pointers, etc., that are implemented by the main program and used by the wl library.
+ *
+ * @var log_printf
+ *      Type: void (*)(const char *format, ...)
+ *      Description: A function pointer that behaves similarly to the standard printf function, accepting a format string and a corresponding variable argument list.
+ *                   This function is used for internal logging within the wl library. The main program implementing this function must ensure it is thread-safe and
+ *                   can handle printf-like format strings and arguments correctly.
+ *                   Example: On certain IoT platforms, a tested and working approach was using 'vprint' function. It's essential that the function provided
+ *                   handles variable argument lists appropriately as in standard 'printf' function.
+ *      Requirement: The main program must provide an implementation of this function and assign this function pointer to it during the initialization of the wl_api_t structure.
+ *
+ * @var log_level
+ *      Type: uint8_t
+ *      Description: Defines the logging level. The wl library will use this level to filter log messages, outputting only those that are at or above this level.
+ *                   It helps in controlling the verbosity of log messages, ensuring that only relevant messages for the current debug or operational level are displayed.
+ *      Requirement: Set by the main program during initialization. The value should be one of the predefined logging level constants (e.g., WL_LOG_LEVEL_INFO, WL_LOG_LEVEL_WARN, etc.).
+ *                   This level will dictate the minimum threshold for log messages. Messages below this severity level will be ignored.
+ */
+
+struct wl_cfg_t
+{
+    uint32_t    status;
+    uint8_t     mode;            // 0b01: wlan; 0b10: bz; 0b11: dual mode
+    uint8_t     en_param_load;   // 0: param is in rentention, no read required; 1: read param during init
+    uint8_t     en_full_cal;     // 0: cal is ready, no full calibration required; 1: do full cal during init
+    uint8_t     en_capcode_set;  // 0: no capcode update; 1: capcode update
+
+    struct wl_param_t param;
+
+    /* platform api to load param data which will be called during init */
+    int8_t (*param_load)(struct wl_param_t* par);
+    /* platform api to set capcode register */
+    void (*capcode_set)(uint8_t capcode_in, uint8_t capcode_out);
+    /* platform api to get capcode register */
+    void (*capcode_get)(uint8_t* capcode_in, uint8_t* capcode_out);
+    /* platform logging api */
+    int (*log_printf)(const char *format, ...);
+
+    uint8_t     log_level;
+    uint8_t     device_info; // QFN40,QFN40M,QFN56
+};
+
+/**
+ * Example of initializing the wireless driver:
+ *
+ * This snippet demonstrates the setup required before initializing the wireless driver.
+ * It involves populating the wl_cfg_t structure with appropriate function handlers and parameters.
+ * Each function handler corresponds to a platform-specific implementation necessary for the wireless driver's operations.
+ *
+ * Retrieve the configuration structure, providing memory allocated for wireless configurations.
+ * struct wl_cfg_t* cfg = wl_cfg_get(RETENSION_MEM_ALLOCATED_FOR_WL);
+ *
+ * Assign a function to set the capcode based on platform-specific requirements.
+ * cfg->capcode_set = function_handler_to_set_capcode;
+ *
+ * Assign a function to retrieve the current capcode, specific to the platform's way of capcode management.
+ * cfg->capcode_get = function_handler_to_get_capcode;
+ *
+ * Assign a platform-dependent function to load necessary parameters required for wireless operations.
+ * cfg->param_load = platform_dependent_param_load_function_handler;
+ *
+ * Enable the loading of parameters, indicating that the driver should use the param_load function.
+ * cfg->en_param_load = 1;
+ *
+ * Enable full calibration mode for more accurate wireless operations.
+ * cfg->en_full_cal = 1;
+ *
+ * Set the operating mode of the wireless driver to WLAN.
+ * cfg->mode = WL_API_MODE_WLAN;
+ *
+ * Additional configuration for logging and device information:
+ * Set the function for logging within the wireless driver.
+ * Here, 'vprint' is a platform-specific implementation of a printf-like function.
+ * cfg->log_printf = vprint;
+ *
+ * Define the logging level, ensuring that only messages of this level or higher are printed.
+ * cfg->log_level = WL_LOG_LEVEL_CRITICAL;
+ *
+ * Set device-specific information.
+ * cfg->device_info = 0;
+ *
+ * Initialize the wireless driver, checking for successful initialization.
+ * int status = wl_init();
+ */
+
+#if WL_API_RMEM_EN
+/* Get retention memory size in bytes for wl driver */
+uint32_t wl_rmem_size_get(void);
+/* Get wireless driver cfg structure:retention sram to save calibration data */
+struct wl_cfg_t* wl_cfg_get(uint8_t* rmem);
+struct wl_env_t* wl_env_get(uint8_t* rmem);
+#else
+struct wl_cfg_t* wl_cfg_get(void);
+#endif
+
+/*
+ * Wireless driver init with param loading and full calibration which can be
+ * skipped by configure en_param_load, en_full_cal in cfg structure
+ */
+int8_t wl_init(void);
+
+/* BB API */
+void wl_wlan_bb_reset(void);
+void wl_wlan_bb_partial_reset(void);
+void wl_wlan_bb_pre_proc(void* rvec_ptr);
+void wl_wlan_bb_post_proc(void* rvec_ptr, uint16_t type_subtype);
+
+/* Get power cfg for rate indicated by formatmod and mcs.
+ * The return value will be filled in transmit descriptor */
+uint8_t wl_wlan_power_cfg_get(uint8_t formatmod, uint8_t rate);
+void wl_wlan_power_table_update(void);
+/* A helper function to read rssi from rvec */
+int8_t wl_wlan_rssi_get(void* rvec_ptr);
+/* A helper function to read ppm from rvec */
+int8_t wl_wlan_ppm_get(void* rvec_ptr);
+/* Get power cfg for bluetooth/802154 phymode which filled in transmit descriptor */
+int8_t wl_154_power_cfg_get(uint8_t phyrate);
+int8_t wl_bt_power_cfg_get(uint8_t phyrate);
+int8_t wl_ble_power_cfg_get(uint8_t phyrate);
+
+/* Temperature calibration should be scheduled periodically */
+int8_t wl_rf_tcal_handler(int16_t temperature);
+/* Get tcal period in seconds */
+uint32_t wl_rf_tcal_period_get(void);
+
+extern struct wl_cfg_t* wl_cfg;
+extern uint8_t*         wl_cal;
+
+/*
+* rf driver api start
+*/
+
+void wl_154_optimize(uint16_t channel_freq); // only for 802154 optimize
+void wl_154_optimize_restore(void); // Restore default setting when exit 802154
+
+void wl_bz_rx_optimize(uint16_t channel_freq); // only for BTBLE Rx optimize
+void wl_bz_rx_optimize_restore(void); // Restore default setting when exit BTBLE
+
+void wl_rf_set_bz_target_power_table(int8_t target_pwr_dbm);// modified the bz power table according to the target power of bz before set bz tx
+void wl_rf_set_154_tx_power(uint32_t target_pwr_dbm);
+int8_t wl_rf_set_154_tx_power_with_power_limit(uint32_t target_pwr_dbm, uint8_t channel_idx, const char *country_code);
+void wl_rf_cfg_init(void);//set default values to rf members of struct, //by Lx
+void wl_rf_set_channel_pwr_comp(uint8_t channel_idx);
+void wl_rf_set_bz_channel_pwr_comp(void);
+void wl_rf_set_status(uint8_t rf_en);// turn on/off rf domain
+void wl_rf_temp_optimize(int16_t temperature); // rf optimize for temperature
+/*
+* rf driver api end
+*/
+
+
+/*
+ * LP API DECLARATIONS
+ ****************************************************************************************
+ */
+#if WL_API_RMEM_EN
+int8_t wl_lp_init(uint8_t* rmem, uint16_t channelfreq_MHz);
+#else
+int8_t wl_lp_init(uint16_t channelfreq_MHz);
+#endif
+void wl_lp_config(uint32_t cfg, uint32_t cfg_cal);
+void wl_lp_status_update(int8_t bcn_rx_status, int8_t bcn_rssi, uint32_t bcn_hbn_time_us);
+uint32_t wl_cal_read(void);
+
+/**
+ * @brief Get phyrf version string
+ *
+ * @return const char* Version string in format "YYYY-MM-DD commit_hash" or "YYYY-MM-DD commit_hash (dirty)"
+ */
+const char* wl_get_version(void);
+
+#endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -175,3 +175,52 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "RF driver library for BL702 (BL70x)"
     doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/73ffff3849ea621dacafdb66835505d6404d7dd8/platform/soc/bl702/bl702_rf
+# BL61x series
+  - path: lib/bl61x/libbtblecontroller_bl616_ble1m0s1bredr0.a
+    sha256: ad7a7f3812bb7ed1f464c86db8569aca958c23c2f0dde7e51d53d422857b9fa3
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/btblecontroller/lib/libbtblecontroller_bl616_ble1m0s1bredr0.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BT/BLE controller for BL616 (peripheral only, 1 connection)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/btblecontroller
+  - path: lib/bl61x/libbtblecontroller_bl616_ble1m10s1bredr0.a
+    sha256: 2f5570bad2831791863bac1a10b95bef3ef6a1c6231139f34c8fed4cdc09a8b2
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/btblecontroller/lib/libbtblecontroller_bl616_ble1m10s1bredr0.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BT/BLE controller for BL616 (peripheral + central, 10 connections)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/btblecontroller
+  - path: lib/bl61x/libbtblecontroller_bl616_ble1m2s1bredr1.a
+    sha256: 508324bc4f2220e0727be1cc56f304d4abd6ed1ee0354d38fcd8efd027abea20
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/btblecontroller/lib/libbtblecontroller_bl616_ble1m2s1bredr1.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BT/BLE controller for BL616 (peripheral + central, 2 connections + BR/EDR)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/btblecontroller
+  - path: lib/bl61x/libbtblecontroller_bl616_bleuarthci.a
+    sha256: 28b287508eb5d7a60c5a4d82a89c5961e9d5ac8c62656a221b0f2d8863e82aa5
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/btblecontroller/lib/libbtblecontroller_bl616_bleuarthci.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BT/BLE controller for BL616 (BLE-only UART HCI transport)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/btblecontroller
+  - path: lib/bl61x/libbtblecontroller_bl616_uarthci.a
+    sha256: ca8bd1fb99c05caeac0e00e348a3e778f7cfc61651cfb295527ee74ae2e5753a
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/components/wireless/bluetooth/btblecontroller/lib/libbtblecontroller_bl616_uarthci.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BT/BLE controller for BL616 (UART HCI transport)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/components/wireless/bluetooth/btblecontroller
+  - path: lib/bl61x/libbl616_phyrf.a
+    sha256: 8d31069276f3647177656e7c3c6bffd55b465aca9c113dc15d4a48f784ace3b4
+    type: lib
+    version: '2.3.23'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.23/drivers/soc/bl616/phyrf/lib-gcc_10.2.0-toolchain_V2.6.1/libbl616_phyrf.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "PHY/RF library for BL616"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.23/drivers/soc/bl616/phyrf


### PR DESCRIPTION
Add minimum required headers and blob declarations for BL616 BLE controller support.

All blobs sourced from `bouffalo_sdk` commit `ad2a37b8`.