### PR TITLE
bflb: add IEEE 802.15.4 (lmac154) headers

### DIFF
--- a/include/bouffalolab/bl61x/lmac154/lmac154.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154.h
@@ -1,0 +1,1644 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_H__
+#define __LMAC154_H__
+
+#define VERSION_LMAC154_MAJOR 1
+#define VERSION_LMAC154_MINOR 7
+#define VERSION_LMAC154_PATCH 2
+
+typedef void (*lmac154_isr_t)(void);
+
+typedef enum {
+    LMAC154_CHANNEL_NONE = -1,
+    LMAC154_CHANNEL_11 = 0,
+    LMAC154_CHANNEL_12,
+    LMAC154_CHANNEL_13,
+    LMAC154_CHANNEL_14,
+    LMAC154_CHANNEL_15,
+    LMAC154_CHANNEL_16,
+    LMAC154_CHANNEL_17,
+    LMAC154_CHANNEL_18,
+    LMAC154_CHANNEL_19,
+    LMAC154_CHANNEL_20,
+    LMAC154_CHANNEL_21,
+    LMAC154_CHANNEL_22,
+    LMAC154_CHANNEL_23,
+    LMAC154_CHANNEL_24,
+    LMAC154_CHANNEL_25,
+    LMAC154_CHANNEL_26,
+}lmac154_channel_t;
+
+typedef enum {
+    LMAC154_TX_POWER_0dBm  = 0,
+    LMAC154_TX_POWER_1dBm  = 1,
+    LMAC154_TX_POWER_2dBm  = 2,
+    LMAC154_TX_POWER_3dBm  = 3,
+    LMAC154_TX_POWER_4dBm  = 4,
+    LMAC154_TX_POWER_5dBm  = 5,
+    LMAC154_TX_POWER_6dBm  = 6,
+    LMAC154_TX_POWER_7dBm  = 7,
+    LMAC154_TX_POWER_8dBm  = 8,
+    LMAC154_TX_POWER_9dBm  = 9,
+    LMAC154_TX_POWER_10dBm = 10,
+    LMAC154_TX_POWER_11dBm = 11,
+    LMAC154_TX_POWER_12dBm = 12,
+    LMAC154_TX_POWER_13dBm = 13,
+    LMAC154_TX_POWER_14dBm = 14,
+}lmac154_tx_power_t;
+
+typedef enum {
+    LMAC154_DATA_RATE_250K = 0,
+    LMAC154_DATA_RATE_500K = 1,
+    LMAC154_DATA_RATE_1M   = 2,
+    LMAC154_DATA_RATE_2M   = 3,
+}lmac154_data_rate_t;
+
+typedef enum {
+    LMAC154_CCA_MODE_ED        = 0,
+    LMAC154_CCA_MODE_CS        = 1,
+    LMAC154_CCA_MODE_ED_AND_CS = 2,
+    LMAC154_CCA_MODE_ED_OR_CS  = 3,
+}lmac154_cca_mode_t;
+
+typedef enum {
+    LMAC154_FRAME_TYPE_BEACON = 0x01,
+    LMAC154_FRAME_TYPE_DATA   = 0x02,
+    LMAC154_FRAME_TYPE_ACK    = 0x04,
+    LMAC154_FRAME_TYPE_CMD    = 0x08,
+    LMAC154_FRAME_TYPE_MPP    = 0x10,
+}lmac154_frame_type_t;
+
+typedef enum {
+    LMAC154_RF_STATE_RX_TRIG        = 1,
+    LMAC154_RF_STATE_RX             = 2,
+    LMAC154_RF_STATE_RX_DOING       = 3,
+    LMAC154_RF_STATE_ACK_DOING      = 4,
+    LMAC154_RF_STATE_TX             = 5,
+    LMAC154_RF_STATE_CSMA           = 6,
+    LMAC154_RF_STATE_IDLE           = 7,
+}lmac154_rf_state_t;
+
+typedef enum {
+    LMAC154_AES_MODE_ENCRYPT = 0,
+    LMAC154_AES_MODE_DECRYPT = 1,
+}lmac154_aes_mode_t;
+
+typedef enum {
+    LMAC154_AES_MIC_LEN_4  = 0,
+    LMAC154_AES_MIC_LEN_8  = 1,
+    LMAC154_AES_MIC_LEN_16 = 2,
+    LMAC154_AES_MIC_LEN_12 = 3,
+}lmac154_aes_mic_len_t;
+
+typedef enum {
+    LMAC154_AES_STATUS_SUCCESS         = 0,
+    LMAC154_AES_STATUS_INVALID_MODE    = -1,
+    LMAC154_AES_STATUS_INVALID_MIC_LEN = -2,
+    LMAC154_AES_STATUS_REENTER         = -3,
+    LMAC154_AES_STATUS_TIMEOUT         = -4,
+}lmac154_aes_status_t;
+
+typedef enum {
+    LMAC154_FPT_STATUS_SUCCESS          = 0,
+    LMAC154_FPT_STATUS_NO_RESOURCE      = -1,
+    LMAC154_FPT_STATUS_ADDR_NOT_FOUND   = -2,
+    LMAC154_FPT_STATUS_EMPTY            = -3,
+    LMAC154_FPT_STATUS_INVALID_PARAM    = -4,
+    LMAC154_FPT_STATUS_INVALID_OPT      = -5
+}lmac154_fpt_status_t;
+
+
+typedef enum {
+    LMAC154_TX_STATUS_TX_FINISHED = 0,
+    LMAC154_TX_STATUS_CSMA_FAILED = 1,
+    LMAC154_TX_STATUS_TX_ABORTED  = 2,
+    LMAC154_TX_STATUS_HW_ERROR    = 3,
+    LMAC154_TX_STATUS_DELAY_ERROR = 4,
+    LMAC154_TX_STATUS_NO_ACK      = 5,
+    LMAC154_TX_STATUS_ACKED       = 6,
+    LMAC154_TX_STATUS_CCA_FAILED  = 7,
+    LMAC154_TX_STATUS_MAX         = 8,
+}lmac154_tx_status_t;
+
+typedef enum {
+    LMAC154_RX_REJECT_CRC_ERR            = 0x00000001, // will reject packets that CRC check error
+    LMAC154_RX_REJECT_FRAME_TYPE_RVSD    = 0x00000002, // will reject packets that the value of frame type filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_FRAME_VER_RVSD     = 0x00000004, // will reject packets that the value of frame version filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_DST_ADDR_M_RVSD    = 0x00000008, // will reject packets that the value of dest address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_SRC_ADDR_M_RVSD    = 0x00000010, // will reject packets that the value of src address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_DST_PANID_MISMATCH = 0x00000020, // will reject packets that the value of dest PANID does not match with local device
+    LMAC154_RX_REJECT_DST_ADDR_MISMATCH  = 0x00000040, // will reject packets that the value of dest address does not match with local device
+    LMAC154_RX_REJECT_SRC_PANID_MISMATCH = 0x00000080, // will reject packets that the value of src PANID does not match with local device
+
+    LMAC154_RX_REJECT_NONE               = 0x00000000, // will not reject all packets above
+    LMAC154_RX_REJECT_ALL                = 0x000000ff, // will reject all packets above
+}lmac154_rx_reject_policy_t;
+
+typedef enum {
+    LMAC154_RX_ACCEPT_CRC_ERR            = 0x00000001, // able to receive packets that CRC check error
+    LMAC154_RX_ACCEPT_FRAME_TYPE_RVSD    = 0x00000002, // able to receive packets that the value of frame type filed is reserved in 802.15.4 spec
+    LMAC154_RX_ACCEPT_FRAME_VER_RVSD     = 0x00000004, // able to receive packets that the value of frame version filed is reserved in 802.15.4 spec
+    LMAC154_RX_ACCEPT_DST_ADDR_M_RVSD    = 0x00000008, // able to receive packets that the value of dest address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_ACCEPT_SRC_ADDR_M_RVSD    = 0x00000010, // able to receive packets that the value of src address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_ACCEPT_DST_PANID_MISMATCH = 0x00000020, // able to receive packets that the value of dest PANID does not match with local device
+    LMAC154_RX_ACCEPT_DST_ADDR_MISMATCH  = 0x00000040, // able to receive packets that the value of dest address does not match with local device
+    LMAC154_RX_ACCEPT_SRC_PANID_MISMATCH = 0x00000080, // able to receive packets that the value of src PANID does not match with local device
+
+    LMAC154_RX_ACCEPT_NONE               = 0x00000000, // not able to receive all packets above
+    LMAC154_RX_ACCEPT_ALL                = 0x000000ff, // able to receive all packets above
+}lmac154_rx_accept_policy_t;
+
+typedef enum {
+    lmac154_addr_info_none               = 0x00000000,
+    lmac154_addr_info_panid              = 0x00000001,
+    lmac154_addr_info_short_addr         = 0x00000002,
+    lmac154_addr_info_ext_addr           = 0x00000004,
+    lmac154_addr_info_panid_short_addr   = lmac154_addr_info_panid | lmac154_addr_info_short_addr,
+    lmac154_addr_info_panid_ext_addr     = lmac154_addr_info_panid | lmac154_addr_info_ext_addr,
+} lmac154_addr_info_t;
+
+typedef struct {
+    uint8_t         rx_length;
+    uint8_t         nbr_idx;
+    uint16_t        rx_error;
+    uint8_t         is_tx_acking:1;
+    uint8_t         is_enh_ack_requested:1;
+    uint8_t         is_frame_pended:1;
+    uint8_t         is_rx_buf:1;
+    uint8_t         channel;
+    int8_t          rssi;
+    int8_t          lqi;
+    uint32_t *      rx_buf[2];
+    uint64_t        rx_timestamp;
+} lmac154_receiveInfo_t;
+
+typedef void (*lmac154_txDoneCallback_t)(lmac154_tx_status_t, uint32_t *, uint32_t);
+typedef uint32_t * (*lmac154_rxDoneCallback_t)(lmac154_receiveInfo_t *, uint32_t *);
+
+typedef struct __lmac154_txParam {
+    uint32_t *                  pkt;
+    uint32_t                    pkt_length:8;
+    uint32_t                    tx_channel:4;
+    uint32_t                    resume_channel:4;
+    uint32_t                    csma_ca_max_backoff:4;
+    uint32_t                    is_cca:1;
+    uint32_t                    is_ack_required:1;
+    uint32_t                    is_enh_ack_required:1;
+    uint32_t                    is_tx_doing:1;
+    uint32_t                    is_last_tx:1;
+    uint32_t                    unused1:7;
+    uint32_t                    unused2;
+    uint32_t                    base_time;
+    uint32_t                    delay_time;
+    lmac154_txDoneCallback_t    tx_done_cb;
+    struct __lmac154_txParam *  next;
+} lmac154_txParam_t;
+
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK       (7)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA       (1)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK        (2)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD        (3)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP        (5)
+
+#define LMAC154_FRAME_SECURITY_MASK                 (1 << 3)
+#define LMAC154_FRAME_FRAME_PENDING_MASK            (1 << 4)
+#define LMAC154_FRAME_ACK_REQUEST_MASK              (1 << 5)
+#define LMAC154_FRAME_PANID_COMPRESSION             (1 << 6)
+#define LMAC154_FRAME_SEQ_SUPRESSION_MASK           (1 << 8)
+#define LMAC154_FRAME_IE_MASK                       (1 << 9)
+#define LMAC154_FRAME_ADDR_DEST_NONE                (0 << 10)
+#define LMAC154_FRAME_ADDR_DEST_SHORT               (2 << 10)
+#define LMAC154_FRAME_ADDR_DEST_EXT                 (3 << 10)
+#define LMAC154_FRAME_ADDR_DEST_MASK                (3 << 10)
+#define LMAC154_FRAME_VERSION_MASK                  (3 << 12)
+#define LMAC154_FRAME_VERSION_2015                  (2 << 12)
+#define LMAC154_FRAME_ADDR_SRC_NONE                 (0 << 14)
+#define LMAC154_FRAME_ADDR_SRC_SHORT                (2 << 14)
+#define LMAC154_FRAME_ADDR_SRC_EXT                  (3 << 14)
+#define LMAC154_FRAME_ADDR_SRC_MASK                 (3 << 14)
+
+#define LMAC154_FRAME_MPP_LONG_FRAME_BIT            (1 << 3)
+#define LMAC154_FRAME_MPP_SECURITY_BIT              (1 << 9)
+#define LMAC154_FRAME_MPP_ACK_REQ                   (1 << 14)
+
+#define LMAC154_FRAME_CMD_DATA_REQUEST              (4)
+#define LMAC154_FRAME_IS_CMD(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD)
+#define LMAC154_FRAME_IS_DATA(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA)
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+
+#define LMAC154_FRAME_IS_ACK_REQ(x)                 (((x) & LMAC154_FRAME_ACK_REQUEST_MASK) == LMAC154_FRAME_ACK_REQUEST_MASK)
+#define LMAC154_FRAME_IS_PANID_COMPRESSED(x)        (((x) & LMAC154_FRAME_PANID_COMPRESSION) == LMAC154_FRAME_PANID_COMPRESSION)
+#define LMAC154_FRAME_IS_SEQ_SUPPURESS(x)           (((x) & LMAC154_FRAME_SEQ_SUPPURESS_MASK) == LMAC154_FRAME_SEQ_SUPPURESS)
+
+
+#define LMAC154_FRAME_IS_FRAME_2015(x)              (((x) & LMAC154_FRAME_VERSION_MASK) == LMAC154_FRAME_VERSION_2015)
+
+#define LMAC154_FRAME_IS_FRAME_PENDED(x)            ((x) & LMAC154_FRAME_FRAME_PENDING_MASK)
+#define LMAC154_FRAME_IS_NORMAL_SECURITY(x)         ((x & LMAC154_FRAME_SECURITY_MASK) == LMAC154_FRAME_SECURITY_MASK)
+
+#define LMAC154_FRAME_IS_MPP(x)                     ((x & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP)
+#define LMAC154_FRAME_IS_MPP_LONG_FRAME(x)          ((x & LMAC154_FRAME_MPP_LONG_FRAME_BIT) == LMAC154_FRAME_MPP_LONG_FRAME_BIT)
+#define LMAC154_FRAME_IS_MPP_SECURITY(x)            (LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_SECURITY_BIT) == LMAC154_FRAME_MPP_SECURITY_BIT)
+
+#define LMAC154_FRAME_IS_MPP_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP(x) && LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_ACK_REQ) == LMAC154_FRAME_MPP_ACK_REQ)
+#define LMAC154_FRAME_IS_ENH_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP_ACK_REQ(x) || (LMAC154_FRAME_IS_ACK_REQ(x) && LMAC154_FRAME_IS_FRAME_2015(x)))
+#define LMAC154_FRAME_IS_IMM_ACK_REQ(x)             (LMAC154_FRAME_IS_ACK_REQ(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+
+#define LMAC154_FRAME_IS_SECURITY_ENABLED(x)        (LMAC154_FRAME_IS_MPP(x) ?                                                          \
+                                                        (LMAC154_FRAME_IS_MPP_SECURITY(x) : LMAC154_FRAME_IS_NORMAL_SECURITY(x))
+
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+#define LMAC154_FRAME_IS_IMM_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_ENH_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_IE_EXIST(x)                (((x) & LMAC154_FRAME_IE_MASK) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+#define LMAC154_FRAME_GET_SRC_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_SRC_MASK)
+#define LMAC154_FRAME_GET_DST_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_DEST_MASK)
+
+
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_MASK          (3 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_0             (0 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_1             (1 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_2             (2 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_3             (3 << 3)
+
+#define LMAC154_LIFS                    40
+#define LMAC154_SIFS                    12
+#define LMAC154_AIFS                    LMAC154_SIFS
+#define LMAC154_SIFS_MAX_FRAME_SIZE     18
+#define LMAC154_TURNAROUND              12
+#define LMAC154_PKT_MAX_LEN             127
+#define LMAC154_PREAMBLE_LEN            8
+
+#define LMAC154_US_PER_SYMBOL_BITS      4
+#define LMAC154_US_PER_SYMBOL           (1 << LMAC154_US_PER_SYMBOL_BITS)
+#define LMAC154_US_PER_SYMBOL_MASK      (LMAC154_US_PER_SYMBOL - 1)
+
+/****************************************************************************//**
+ * @brief  Initialize the hardware module
+ *         Call this function first
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_init(void);
+
+/****************************************************************************//**
+ * @brief  Enable MAC 15.4 2015 standard feature
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015(bool isEnable);
+
+/****************************************************************************//**
+ * @brief  Enable MAC 15.4 2015 standard feature with extra configuration
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015Extra(bool isEnable);
+
+
+/****************************************************************************//**
+ * @brief  Enable second stack for dual stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2ndStack(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable second stack for dual stack, which is disable by default
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2ndStack(void);
+
+
+/****************************************************************************//**
+ * @brief  Check whether the second stack is enabled
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+uint32_t lmac154_is2ndStackEnabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Get whether lmac154 is disabled
+ *
+ * @param  None
+ *
+ * @return 1 for disabled, 0 for enabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isDisabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Monitor the hardware state
+ *
+ * @param  monitor_timeout, monitor timeout in ms
+ *
+ * @return monitor result
+ *
+*******************************************************************************/
+int lmac154_monitor(uint32_t monitor_timeout);
+
+/****************************************************************************//**
+ * @brief  Get the lmac154 interrupt handler for interrupt registration of M154_IRQn
+ *
+ * @param  None
+ *
+ * @return The lmac154 interrupt handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptHandler(void);
+
+
+/****************************************************************************//**
+ * @brief  Register rx done event callback and get m154 irq handler
+ *
+ * @param  stack_rxDoneCallback, frame received with destination panid on stack 1
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_registerEventCallback(lmac154_rxDoneCallback_t stack_rxDoneCallback);
+
+/****************************************************************************//**
+ * @brief  Register rx done event callback and get m154 irq handler
+ *
+ * @param  stack1_rxDoneCallback, frame received with destination panid on stack 1
+ *
+ * @param  stack2_rxDoneCallback, frame received with destination panid on stack 2
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_registerEventDualCallbacks(lmac154_rxDoneCallback_t stack1_rxDoneCallback,
+                                                 lmac154_rxDoneCallback_t stack2_rxDoneCallback);
+
+/****************************************************************************//**
+ * @brief  Get the version number
+ *
+ * @param  None
+ *
+ * @return The library version number
+ *
+*******************************************************************************/
+uint32_t lmac154_getVersionNumber(void);
+
+/****************************************************************************//**
+ * @brief  Get the version number string
+ *
+ * @param  None
+ *
+ * @return The library version number string
+ *
+*******************************************************************************/
+char * lmac154_getVersionString(void);
+
+/****************************************************************************//**
+ * @brief  Enable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer accepts all frames received from the PHY layer
+ *         Able to receive frames without any IFS but rx sensitivity may be degraded if enhanced_mode = 1
+ *         The MPDU is unavailable in lmac154_rxDoneEvent if ignore_mpdu = 1
+ *
+ * @param  enhanced_mode: 0: standard mode, 1: enhanced mode
+ * @param  ignore_mpdu: 0: read mpdu from registers, 1: do not read mpdu from registers
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxPromiscuousMode(uint8_t enhanced_mode, uint8_t ignore_mpdu);
+
+
+/****************************************************************************//**
+ * @brief  Disable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer only accepts frames that pass the address filtering
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxPromiscuousMode(void);
+
+
+/****************************************************************************//**
+ * @brief  Get whether rx promiscuous mode is enabled
+ *
+ * @param  None
+ *
+ * @return 1 for enabled; 0 for disabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isRxPromiscuousModeEnabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRx(void);
+
+/****************************************************************************//**
+ * @brief  try to force enable rx
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_forceEnableRX(void);
+
+/****************************************************************************//**
+ * @brief  Disable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRx(void);
+
+
+/****************************************************************************//**
+ * @brief  Set rx on/off state when idle state
+ *
+ * @param  isRxOnWhenIdle: true is rx on when idle; otherwhile is rx off when idle
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxStateWhenIdle(bool isRxOnWhenIdle);
+
+/****************************************************************************//**
+ * @brief  Get rx on/off state when idle state
+ *
+ * @param  None
+ *
+ * @return true is rx on when idle; otherwhile is rx off when idle
+ *
+*******************************************************************************/
+bool lmac154_isRxStateWhenIdle(void);
+
+/****************************************************************************//**
+ * @brief  Set the number of maximum retransmission times (default 0)
+ *         Will perform retransmission in case ack is not received if num > 0
+ *         Will raise lmac154_ackEvent(ack_received = 0) after maximum retransmission times
+ *
+ * @param  num: number of maximum retransmission times
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRetry(uint32_t num);
+
+
+/****************************************************************************//**
+ * @brief  Trigger TX
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma: 0: without CSMA, 1: with CSMA
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_triggerTx(uint8_t *DataPtr, uint8_t length, uint8_t csma);
+
+
+/****************************************************************************//**
+ * @brief  Trigger TX with paramter, which is required critical section protection
+ *
+ * @param  txParam: paramter to trigger tx
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTx(lmac154_txParam_t * txParam);
+
+/****************************************************************************//**
+ * @brief  Write TX ack frame to mpdu buffer to send in lmac154_receivedEvent
+ *         with isEnhAckExpected true.
+ *
+ * @param  ack_frame: pointer to data buffer of ack frame
+ * @param  ack_frame_length: data length in bytes
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_writeTxAckFrame(uint8_t *ack_frame, int ack_frame_length);
+
+/****************************************************************************//**
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerParamTx
+ *         is called with time specified
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 1 is selected
+ *
+*******************************************************************************/
+uint32_t lmac154_isTriggerTimeSelected(void);
+
+/****************************************************************************//**
+ * @brief  Run tx continuous modulation (PRBS15 pattern)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCM(void);
+
+/****************************************************************************//**
+ * @brief  Reset tx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetTx(void);
+
+/****************************************************************************//**
+ * @brief  Reset rx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetRx(void);
+
+/****************************************************************************//**
+ * @brief  Set the channel (default LMAC154_CHANNEL_11)
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setChannel(lmac154_channel_t ch_ind);
+
+
+/****************************************************************************//**
+ * @brief  Get the channel
+ *
+ * @param  None
+ *
+ * @return The channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+*******************************************************************************/
+lmac154_channel_t lmac154_getChannel(void);
+
+
+/****************************************************************************//**
+ * @brief  Get RSSI in dBm
+ *
+ * @param  None
+ *
+ * @return RSSI in dBm
+ *
+*******************************************************************************/
+int lmac154_getRSSI(void);
+
+
+/****************************************************************************//**
+ * @brief  Get LQI
+ *
+ * @param  None
+ *
+ * @return LQI
+ *
+*******************************************************************************/
+int lmac154_getLQI(void);
+
+
+/****************************************************************************//**
+ * @brief  Get SFD correlation
+ *
+ * @param  None
+ *
+ * @return SFD correlation
+ *
+*******************************************************************************/
+uint8_t lmac154_getSFDCorrelation(void);
+
+
+/****************************************************************************//**
+ * @brief  Get the frequency offset in Hz
+ *
+ * @param  None
+ *
+ * @return The frequency offset in Hz
+ *
+*******************************************************************************/
+int lmac154_getFrequencyOffset(void);
+
+/****************************************************************************//**
+ * @brief  Set country code for tx power adjustment
+ *
+ * @param  country_code: country code, for example: CN
+ *
+ * @return true, if country code is valid.
+ *
+*******************************************************************************/
+bool lmac154_setCountryCode(const char * country_code);
+
+/****************************************************************************//**
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPower(lmac154_tx_power_t power_dbm);
+
+/****************************************************************************//**
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @param country_code: country code, for example: CN
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPowerWithPowerLimit(lmac154_tx_power_t power_dbm, lmac154_channel_t ch_ind, const char *country_code);
+
+/****************************************************************************//**
+ * @brief  Get tx power
+ *
+ * @param  None
+ *
+ * @return tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+*******************************************************************************/
+lmac154_tx_power_t lmac154_getTxPower(void);
+
+
+/****************************************************************************//**
+ * @brief  Set tx data rate (default LMAC154_DATA_RATE_250K)
+ *         The maximum tx mpdu length is 127 bytes for 250kbps tx data rate, and 255 bytes for others
+ *
+ * @param  rate: LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxDataRate(lmac154_data_rate_t rate);
+
+
+/****************************************************************************//**
+ * @brief  Enable auto rx data rate (default disabled)
+ *         The maximum rx mpdu length is 127 bytes for 250kbps rx data rate, and 255 bytes for others
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAutoRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable auto rx data rate (default disabled)
+ *         The rx data rate is 250kbps, and the maximum rx mpdu length is 127 bytes
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAutoRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Get rx data rate
+ *
+ * @param  None
+ *
+ * @return LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+*******************************************************************************/
+lmac154_data_rate_t lmac154_getRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Set CCA mode (default LMAC154_CCA_MODE_ED_AND_CS)
+ *
+ * @param  mode: LMAC154_CCA_MODE_ED, LMAC154_CCA_MODE_CS, LMAC154_CCA_MODE_ED_AND_CS, or LMAC154_CCA_MODE_ED_OR_CS
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCCAMode(lmac154_cca_mode_t mode);
+
+
+/****************************************************************************//**
+ * @brief  Set CCA ED threshold (default -71dBm)
+ *
+ * @param  threshold: ED threshold ranging from -122 to 5 in dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEDThreshold(int threshold);
+
+
+/****************************************************************************//**
+ * @brief  Get CCA ED threshold
+ *
+ * @param  None
+ *
+ * @return ED threshold
+ *
+*******************************************************************************/
+int lmac154_getEDThreshold(void);
+
+
+/****************************************************************************//**
+ * @brief  Run CCA
+ *
+ * @param  rssi: rssi output ranging from -122 to 5 in dBm
+ *
+ * @return CCA result: 0: channel idle, 1: channel busy
+ *
+*******************************************************************************/
+uint8_t lmac154_runCCA(int *rssi);
+
+
+/****************************************************************************//**
+ * @brief  Set PAN ID (default 0x4321)
+ *
+ * @param  pid: PAN ID
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setPanId(uint16_t pid);
+void lmac154_set2ndPanId(uint16_t pid);
+
+
+/****************************************************************************//**
+ * @brief  Get PAN ID
+ *
+ * @param  None
+ *
+ * @return PAN ID
+ *
+*******************************************************************************/
+uint16_t lmac154_getPanId(void);
+uint16_t lmac154_get2ndPanId(void);
+
+
+/****************************************************************************//**
+ * @brief  Set 16-bit short address (default 0x0000)
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setShortAddr(uint16_t sadr);
+void lmac154_set2ndShortAddr(uint16_t sadr);
+
+
+/****************************************************************************//**
+ * @brief  Get 16-bit short address
+ *
+ * @param  None
+ *
+ * @return 16-bit short address
+ *
+*******************************************************************************/
+uint16_t lmac154_getShortAddr(void);
+uint16_t lmac154_get2ndShortAddr(void);
+
+
+/****************************************************************************//**
+ * @brief  Set 64-bit long address (default 0xACDE4800_00000002)
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setLongAddr(uint8_t *ladr);
+void lmac154_set2ndLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Get 64-bit long address
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getLongAddr(uint8_t *ladr);
+void lmac154_get2ndLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Enable frame type filtering (default disabled)
+ *         Will only receive specified frame types
+ *
+ * @param  frame_types: any combination of LMAC154_FRAME_TYPE_XXX (BEACON, DATA, ACK, or CMD), via bitwise OR ('|') operation
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableFrameTypeFiltering(uint8_t frame_types);
+
+
+/****************************************************************************//**
+ * @brief  Disable frame type filtering (default disabled)
+ *         Will receive all valid frame types (BEACON, DATA, ACK, or CMD)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableFrameTypeFiltering(void);
+
+
+/****************************************************************************//**
+ * @brief  Set rx reject policy
+ *
+ * @param policy : enum lmac154_rx_reject_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxRejectPolicy(lmac154_rx_reject_policy_t policy);
+
+
+/****************************************************************************//**
+ * @brief  Get rx reject policy
+ *
+ * @param None
+ *
+ * @return Rx reject policy
+ *
+*******************************************************************************/
+lmac154_rx_reject_policy_t lmac154_getRxRejectPolicy(void);
+
+
+/****************************************************************************//**
+ * @brief  set rx accept policy
+ *
+ *
+ * @param policy : enum lmac154_rx_accept_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxAcceptPolicy(lmac154_rx_accept_policy_t policy);
+
+
+/****************************************************************************//**
+ * @brief  get rx accept policy
+ *
+ *
+ * @param None
+ *
+ * @return lmac154_rx_accept_policy : enum lmac154_rx_accept_policy_t
+ *
+*******************************************************************************/
+lmac154_rx_accept_policy_t lmac154_getRxAcceptPolicy(void);
+
+/****************************************************************************//**
+ * @brief  Get RF state
+ *
+ * @param  None
+ *
+ * @return LMAC154_RF_STATE_RX, LMAC154_RF_STATE_RX_DOING, LMAC154_RF_STATE_TX, or LMAC154_RF_STATE_IDLE
+ *
+*******************************************************************************/
+lmac154_rf_state_t lmac154_getRFState(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableCoex(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableCoex(void);
+
+
+/****************************************************************************//**
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCoexPriority(bool is_rx_on_after_rx_abort_enable, uint32_t tx_priority,
+    uint32_t rx_unicast_priority, uint32_t rx_sfd_priority, uint32_t rx_idle_priority);
+
+/****************************************************************************//**
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getCoexPriority(bool * is_rx_on_after_rx_abort_enable, uint32_t * tx_priority,
+    uint32_t * rx_unicast_priority, uint32_t * rx_sfd_priority, uint32_t * rx_idle_priority);
+
+/****************************************************************************//**
+ * @brief  Enable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableTxAbortInt(void);
+
+/****************************************************************************//**
+ * @brief  Disable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableTxAbortInt(void);
+
+/****************************************************************************//**
+ * @brief  Enable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableHwAutoTxAck(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableHwAutoTxAck(void);
+
+/****************************************************************************//**
+ * @brief  Get whether hardware auto transmission of ack frame is enabled
+ *
+ * @param  None
+ *
+ * @return ture, enabled
+ *
+*******************************************************************************/
+bool lmac154_isHwAutoTxAckEnabled(void);
+
+/****************************************************************************//**
+ * @brief  Enable lmac154_ackEvent (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable lmac154_ackEvent (default enabled)
+ *         Will raise lmac154_rxDoneEvent instead when ack is received
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxSecMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxSecMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableReqEnhAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableReqEnhAckEvent(void);
+
+/****************************************************************************//**
+ * @brief  Get the receiving or received mpdu length in bytes (crc included)
+ *
+ * @param  None
+ *
+ * @return The receiving or received mpdu length
+ *
+*******************************************************************************/
+uint8_t lmac154_getRxLength(void);
+
+
+/****************************************************************************//**
+ * @brief  Read rx data (crc not included)
+ *
+ * @param  buf: pointer to data buffer
+ * @param  offset: data offset ranging from 0 to 252 in bytes
+ * @param  len: data length ranging from 1 to 253-offset in bytes
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxData(uint8_t *buf, uint8_t offset, uint8_t len);
+
+
+/****************************************************************************//**
+ * @brief  Read rx crc
+ *
+ * @param  crc: byte array to carry rx crc
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxCrc(uint8_t crc[2]);
+
+
+/****************************************************************************//**
+ * @brief  Set the maximum wait time for ack frame (default 864us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setAckWaitTime(uint16_t time_us);
+
+/****************************************************************************//**
+ * @brief  Get the maximum wait time for imm-ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getAckWaitTime(void);
+
+/****************************************************************************//**
+ * @brief  Set the maximum wait time for enh-ack ack frame (default 1500us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEnhAckWaitTime(uint16_t time_us);
+
+/****************************************************************************//**
+ * @brief  Get the maximum wait time for enh-ack ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getEnhAckWaitTime(void);
+
+/****************************************************************************//**
+ * @brief  Set the maximum and minimum CSMA-CA backoff exponent
+ *
+ * @param  max_be: maximum BE ranging from 3 to 8, default 5
+ * @param  min_be: minimum BE ranging from 0 to max_be, default 3
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setBE(uint8_t max_be, uint8_t min_be);
+
+/****************************************************************************//**
+ * @brief  Set maximum CSMA backoff
+ *
+ * @param  maxBackoff: maximum CSMA backoff
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setMaxCsmaBackoff(uint8_t maxBackoff);
+
+/****************************************************************************//**
+ * @brief  Set tx-rx transition time
+ *
+ * @param  time: us
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRxTransTime(uint8_t timeInUs);
+
+uint64_t lmac154_get_current_timestamp(void);
+uint64_t lmac154_get_rx_start_timestamp(void);
+uint64_t lmac154_get_rx_done_timestamp(void);
+uint64_t lmac154_get_tx_done_timestamp(void);
+
+bool lmac154_fptSetMaxNum(uint32_t shortAddrNum, uint32_t longAddrNum);
+
+/****************************************************************************//**
+ * @brief  Run AES CCM
+ *
+ * @param  mode: LMAC154_AES_MODE_ENCRYPT or LMAC154_AES_MODE_DECRYPT
+ * @param  a_data: pointer to additional authentication data buffer
+ * @param  a_len: length of additional authentication data in bytes
+ * @param  nonce: pointer to 13-byte nonce buffer
+ * @param  key: pointer to 4-word key buffer
+ * @param  mic_len: LMAC154_MIC_LEN_4, LMAC154_MIC_LEN_8, LMAC154_MIC_LEN_12, or LMAC154_MIC_LEN_16
+ * @param  mic: pointer to mic buffer
+ * @param  input_data: pointer to input data buffer
+ * @param  output_data: pointer to output data buffer
+ * @param  len: length of input data in bytes
+ *
+ * @return The error code
+ *
+*******************************************************************************/
+lmac154_aes_status_t lmac154_runAESCCM(lmac154_aes_mode_t mode,
+                                       const uint8_t *a_data,
+                                       uint8_t a_len,
+                                       const uint8_t *nonce,
+                                       const uint32_t *key,
+                                       lmac154_aes_mic_len_t mic_len,
+                                       uint32_t *mic,
+                                       const uint32_t *input_data,
+                                       uint32_t *output_data,
+                                       uint8_t len);
+
+
+
+
+// hardware frame pending table (256 bytes)
+// shared by short addresses and long addresses (supports up to 128 short addresses or 32 long addresses or mixed)
+// used by hardware to set the frame pending bit of hw auto tx ack
+// if the address is not found in the table (e.g. not set or removed), the frame pending bit of hw auto tx ack is 1
+
+
+/****************************************************************************//**
+ * @brief  Add (or update) the key-value pair {sadr: pending} to (in) the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetShortAddrPending(uint16_t sadr, uint8_t pending);
+
+
+/****************************************************************************//**
+ * @brief  Add (or update) the key-value pair {ladr: pending} to (in) the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetLongAddrPending(uint8_t *ladr, uint8_t pending);
+
+
+/****************************************************************************//**
+ * @brief  Get the corresponding frame pending bit of the short address in the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetShortAddrPending(uint16_t sadr, uint8_t *pending);
+
+/****************************************************************************//**
+ * @brief  Get the corresponding frame pending bit of the long address in the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetLongAddrPending(uint8_t *ladr, uint8_t *pending);
+
+/****************************************************************************//**
+ * @brief  Remove the key-value pair {sadr: pending} from the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveShortAddr(uint16_t sadr);
+
+
+/****************************************************************************//**
+ * @brief  Remove the key-value pair {ladr: pending} from the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Get short address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetShortAddrList(void *list, uint8_t *entry_num);
+
+
+/****************************************************************************//**
+ * @brief  Get long address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetLongAddrList(void *list, uint8_t *entry_num);
+
+
+/****************************************************************************//**
+ * @brief  Set frame pending bit according to frame pending table, or force to set to 1
+ *
+ * @param  force: 0: set according to frame pending table (default), 1: force to set to 1
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptForcePending(uint8_t force);
+
+
+/****************************************************************************//**
+ * @brief  Clear the frame pending table
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptClear(void);
+
+
+/****************************************************************************//**
+ * @brief  Print the frame pending table using specified print function
+ *
+ * @param  print_func: user specified print function
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptDump(int print_func(const char *fmt, ...));
+
+
+// functions below are callback functions running in the interrupt context
+// should be implemented by user if needed
+
+
+/****************************************************************************//**
+ * @brief  Tx Done Event
+ *         Will be raised after calling lmac154_triggerTx
+ *
+ * @param  tx_status: LMAC154_TX_STATUS_XXX (TX_FINISHED, CSMA_FAILED, TX_ABORTED, or HW_ERROR)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_txDoneEvent(lmac154_tx_status_t tx_status);
+
+
+/****************************************************************************//**
+ * @brief  Ack Event
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  frame_pending: frame pending bit in ack frame
+ * @param  seq_num: sequence number in ack frame
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackEvent(uint8_t ack_received, uint8_t frame_pending, uint8_t seq_num);
+
+
+/****************************************************************************//**
+ * @brief  Ack Event with ack frame
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  rx_buf: pointer to the ack frame buffer
+ * @param  len: ACK frame length
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackFrameEvent(uint8_t ack_received, uint8_t *rx_buf, uint8_t len);
+
+
+/****************************************************************************//**
+ * @brief  Rx Done Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received mpdu length in bytes (crc included)
+ * @param  crc_fail: 0: crc pass, 1: crc fail
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxDoneEvent(uint8_t *rx_buf, uint8_t rx_len, uint32_t crc_fail);
+
+/****************************************************************************//**
+ * @brief  Rx Start Event
+ *         Will be raised when rx on MAC sublayer starts
+ *         lmac154_getRxLength is available because it is obtained from PHY layer
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Hardware auto tx ack done event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_hwAutoTxAckDoneEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  A 2015 version unicast packet received and enh-ack is required to respond
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_reqEnhAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+
+/****************************************************************************//**
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxSecMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get memory address of destination PAN ID
+ *         and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to the destination PAN ID in input frame, if present.
+ * @param  a_sa: pointer to destination short address in input frame, if present.
+ * @param  a_xa: pointer to destination extended address in input frame,
+ *               if present.
+ * @return None
+*******************************************************************************/
+void lmac154_parseDestAddress(uint8_t * a_pkt, uint16_t ** a_panid,
+                              uint16_t ** a_sa, uint8_t ** a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get memory address of source PANID
+ *         and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to the source PAN ID in input frame, if present.
+ * @param  a_sa: pointer to source short address in input frame, if present.
+ * @param  a_xa: pointer to source extended address in input frame, if present.
+ *
+ * @return None
+*******************************************************************************/
+void lmac154_parseSrcAddress(uint8_t * a_pkt, uint16_t **a_panid,
+                             uint16_t ** a_sa, uint8_t ** a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get destination PAN ID and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to save destination PAN ID from input frame
+ * @param  a_sa: pointer to save destination short address from input frame,
+ *              if present.
+ * @param  a_xa: pointer to save destination extended address from input frame,
+ *              if present.
+ *
+ * @return lmac154_addr_info_t to indicate information of source address
+*******************************************************************************/
+lmac154_addr_info_t lmac154_getDestAddress(uint8_t * a_pkt, uint16_t * a_panid,
+                                           uint16_t * a_sa, uint8_t * a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get source PAN ID and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to save source PAN ID from input frame
+ * @param  a_sa: pointer to save source short address from input frame,
+ *              if present.
+ * @param  a_xa: pointer to save source extended address from input frame,
+ *              if present.
+ *
+ * @return lmac154_addr_info_t to indicate information of source address
+*******************************************************************************/
+lmac154_addr_info_t lmac154_getSrcAddress(uint8_t * a_pkt, uint16_t * a_panid,
+                                          uint16_t * a_sa, uint8_t * a_xa);
+
+#endif

--- a/include/bouffalolab/bl61x/lmac154/lmac154.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154.h
@@ -1,0 +1,1685 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_H__
+#define __LMAC154_H__
+
+#define VERSION_LMAC154_MAJOR 1
+#define VERSION_LMAC154_MINOR 7
+#define VERSION_LMAC154_PATCH 7
+
+#ifndef CONFIG_LMAC154_DBG
+#define CONFIG_LMAC154_DBG 0
+#endif
+
+#define M154_RD_WORD(addr)                          (*((volatile uint32_t *)(uintptr_t)(addr)))
+#define M154_WR_WORD(addr, val)                     ((*(volatile uint32_t *)(uintptr_t)(addr)) = (val))
+#define M154_RD_REG(addr, regname)                  M154_RD_WORD(addr + regname##_OFFSET)
+#define M154_WR_REG(addr, regname, val)             M154_WR_WORD(addr + regname##_OFFSET, val)
+
+#define M154_SET_REG_BIT(val, bitname)              ((val) | (1U << bitname##_POS))
+#define M154_CLR_REG_BIT(val, bitname)              ((val)&bitname##_UMSK)
+#define M154_GET_REG_BITS_VAL(val, bitname)         (((val)&bitname##_MSK) >> bitname##_POS)
+#define M154_SET_REG_BITS_VAL(val, bitname, bitval) (((val)&bitname##_UMSK) | ((uint32_t)(bitval) << bitname##_POS))
+#define M154_IS_REG_BIT_SET(val, bitname)           (((val) & (1U << (bitname##_POS))) != 0)
+
+typedef void (*lmac154_isr_t)(void);
+
+typedef enum {
+    LMAC154_CHANNEL_NONE = -1,
+    LMAC154_CHANNEL_11 = 0,
+    LMAC154_CHANNEL_12,
+    LMAC154_CHANNEL_13,
+    LMAC154_CHANNEL_14,
+    LMAC154_CHANNEL_15,
+    LMAC154_CHANNEL_16,
+    LMAC154_CHANNEL_17,
+    LMAC154_CHANNEL_18,
+    LMAC154_CHANNEL_19,
+    LMAC154_CHANNEL_20,
+    LMAC154_CHANNEL_21,
+    LMAC154_CHANNEL_22,
+    LMAC154_CHANNEL_23,
+    LMAC154_CHANNEL_24,
+    LMAC154_CHANNEL_25,
+    LMAC154_CHANNEL_26,
+}lmac154_channel_t;
+
+typedef enum {
+    LMAC154_TX_POWER_0dBm  = 0,
+    LMAC154_TX_POWER_1dBm  = 1,
+    LMAC154_TX_POWER_2dBm  = 2,
+    LMAC154_TX_POWER_3dBm  = 3,
+    LMAC154_TX_POWER_4dBm  = 4,
+    LMAC154_TX_POWER_5dBm  = 5,
+    LMAC154_TX_POWER_6dBm  = 6,
+    LMAC154_TX_POWER_7dBm  = 7,
+    LMAC154_TX_POWER_8dBm  = 8,
+    LMAC154_TX_POWER_9dBm  = 9,
+    LMAC154_TX_POWER_10dBm = 10,
+    LMAC154_TX_POWER_11dBm = 11,
+    LMAC154_TX_POWER_12dBm = 12,
+    LMAC154_TX_POWER_13dBm = 13,
+    LMAC154_TX_POWER_14dBm = 14,
+}lmac154_tx_power_t;
+
+typedef enum {
+    LMAC154_DATA_RATE_250K = 0,
+    LMAC154_DATA_RATE_500K = 1,
+    LMAC154_DATA_RATE_1M   = 2,
+    LMAC154_DATA_RATE_2M   = 3,
+}lmac154_data_rate_t;
+
+typedef enum {
+    LMAC154_CCA_MODE_ED        = 0,
+    LMAC154_CCA_MODE_CS        = 1,
+    LMAC154_CCA_MODE_ED_AND_CS = 2,
+    LMAC154_CCA_MODE_ED_OR_CS  = 3,
+}lmac154_cca_mode_t;
+
+typedef enum {
+    LMAC154_FRAME_TYPE_BEACON = 0x01,
+    LMAC154_FRAME_TYPE_DATA   = 0x02,
+    LMAC154_FRAME_TYPE_ACK    = 0x04,
+    LMAC154_FRAME_TYPE_CMD    = 0x08,
+    LMAC154_FRAME_TYPE_MPP    = 0x10,
+}lmac154_frame_type_t;
+
+typedef enum {
+    LMAC154_RF_STATE_RX_TRIG        = 1,
+    LMAC154_RF_STATE_RX             = 2,
+    LMAC154_RF_STATE_RX_DOING       = 3,
+    LMAC154_RF_STATE_ACK_DOING      = 4,
+    LMAC154_RF_STATE_TX             = 5,
+    LMAC154_RF_STATE_CSMA           = 6,
+    LMAC154_RF_STATE_IDLE           = 7,
+}lmac154_rf_state_t;
+
+typedef enum {
+    LMAC154_AES_MODE_ENCRYPT = 0,
+    LMAC154_AES_MODE_DECRYPT = 1,
+}lmac154_aes_mode_t;
+
+typedef enum {
+    LMAC154_AES_MIC_LEN_4  = 0,
+    LMAC154_AES_MIC_LEN_8  = 1,
+    LMAC154_AES_MIC_LEN_16 = 2,
+    LMAC154_AES_MIC_LEN_12 = 3,
+}lmac154_aes_mic_len_t;
+
+typedef enum {
+    LMAC154_AES_STATUS_SUCCESS         = 0,
+    LMAC154_AES_STATUS_INVALID_MODE    = -1,
+    LMAC154_AES_STATUS_INVALID_MIC_LEN = -2,
+    LMAC154_AES_STATUS_REENTER         = -3,
+    LMAC154_AES_STATUS_TIMEOUT         = -4,
+}lmac154_aes_status_t;
+
+typedef enum {
+    LMAC154_FPT_STATUS_SUCCESS          = 0,
+    LMAC154_FPT_STATUS_NO_RESOURCE      = -1,
+    LMAC154_FPT_STATUS_ADDR_NOT_FOUND   = -2,
+    LMAC154_FPT_STATUS_EMPTY            = -3,
+    LMAC154_FPT_STATUS_INVALID_PARAM    = -4,
+    LMAC154_FPT_STATUS_INVALID_OPT      = -5
+}lmac154_fpt_status_t;
+
+typedef enum {
+    LMAC154_TX_STATUS_TX_FINISHED = 0,
+    LMAC154_TX_STATUS_ACKED       = 1,
+    LMAC154_TX_STATUS_CSMA_FAILED = 2,
+    LMAC154_TX_STATUS_TX_ABORTED  = 3,
+    LMAC154_TX_STATUS_HW_ERROR    = 4,
+    LMAC154_TX_STATUS_DELAY_ERROR = 5,
+    LMAC154_TX_STATUS_NO_ACK      = 6,
+    LMAC154_TX_STATUS_CCA_FAILED  = 7,
+    LMAC154_TX_STATUS_MAX         = 8,
+}lmac154_tx_status_t;
+
+typedef enum {
+    LMAC154_RX_REJECT_CRC_ERR            = 0x00000001, /* will reject packets that CRC check error */
+    LMAC154_RX_REJECT_FRAME_TYPE_RVSD    = 0x00000002, /* will reject packets that the value of frame type filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_FRAME_VER_RVSD     = 0x00000004, /* will reject packets that the value of frame version filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_DST_ADDR_M_RVSD    = 0x00000008, /* will reject packets that the value of dest address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_SRC_ADDR_M_RVSD    = 0x00000010, /* will reject packets that the value of src address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_DST_PANID_MISMATCH = 0x00000020, /* will reject packets that the value of dest PANID does not match with local device */
+    LMAC154_RX_REJECT_DST_ADDR_MISMATCH  = 0x00000040, /* will reject packets that the value of dest address does not match with local device */
+    LMAC154_RX_REJECT_SRC_PANID_MISMATCH = 0x00000080, /* will reject packets that the value of src PANID does not match with local device */
+
+    LMAC154_RX_REJECT_NONE               = 0x00000000, /* will not reject all packets above */
+    LMAC154_RX_REJECT_ALL                = 0x000000ff, /* will reject all packets above */
+}lmac154_rx_reject_policy_t;
+
+typedef enum {
+    LMAC154_RX_ACCEPT_CRC_ERR            = 0x00000001, /* able to receive packets that CRC check error */
+    LMAC154_RX_ACCEPT_FRAME_TYPE_RVSD    = 0x00000002, /* able to receive packets that the value of frame type filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_FRAME_VER_RVSD     = 0x00000004, /* able to receive packets that the value of frame version filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_DST_ADDR_M_RVSD    = 0x00000008, /* able to receive packets that the value of dest address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_SRC_ADDR_M_RVSD    = 0x00000010, /* able to receive packets that the value of src address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_DST_PANID_MISMATCH = 0x00000020, /* able to receive packets that the value of dest PANID does not match with local device */
+    LMAC154_RX_ACCEPT_DST_ADDR_MISMATCH  = 0x00000040, /* able to receive packets that the value of dest address does not match with local device */
+    LMAC154_RX_ACCEPT_SRC_PANID_MISMATCH = 0x00000080, /* able to receive packets that the value of src PANID does not match with local device */
+
+    LMAC154_RX_ACCEPT_NONE               = 0x00000000, /* not able to receive all packets above */
+    LMAC154_RX_ACCEPT_ALL                = 0x000000ff, /* able to receive all packets above */
+}lmac154_rx_accept_policy_t;
+
+typedef enum {
+    lmac154_addr_info_none               = 0x00000000,
+    lmac154_addr_info_panid              = 0x00000001,
+    lmac154_addr_info_short_addr         = 0x00000002,
+    lmac154_addr_info_ext_addr           = 0x00000004,
+    lmac154_addr_info_panid_short_addr   = lmac154_addr_info_panid | lmac154_addr_info_short_addr,
+    lmac154_addr_info_panid_ext_addr     = lmac154_addr_info_panid | lmac154_addr_info_ext_addr,
+} lmac154_addr_info_t;
+
+typedef void (*lmac154_txDoneCallback_t)(lmac154_tx_status_t, uint32_t *, uint32_t);
+
+/**
+ * @brief RX callback status codes
+ */
+typedef enum {
+    LMAC154_RX_STATUS_NONE          = 0,
+    LMAC154_RX_STATUS_RX_DONE       = 1,
+    LMAC154_RX_STATUS_ACK_SENT      = 2,
+    LMAC154_RX_STATUS_ACK_ERR       = 3,
+} lmac154_rx_status_t;
+
+typedef struct lmac154_receiveInfo lmac154_receiveInfo_t;
+
+typedef void (*lmac154_rxDoneCallback_t)(lmac154_rx_status_t, lmac154_receiveInfo_t *, uint32_t *);
+
+struct lmac154_receiveInfo {
+    uint32_t                        rx_length:8;
+    uint32_t                        nbr_idx:8;
+    uint32_t                        mac_hdr_size:8;
+    uint32_t                        is_tx_acking:1;
+    uint32_t                        is_enh_ack_requested:1;
+    uint32_t                        is_frame_pended:1;
+    uint32_t                        is_src_saddr:1;
+    uint32_t                        is_src_xaddr:1;
+    uint32_t                        stack_msk:2;
+    uint32_t                        unused:1;
+    uint16_t                        rx_error;
+    uint8_t                         enh_ack_time;
+    uint8_t                         dbg_en:1;
+    uint8_t                         dbg_rx_filter_en:1;
+    uint8_t                         dbg_ack_len:6;
+    int8_t                          dbg_ack_cost;
+    int8_t                          dbg_csl_drift_ack;
+    uint16_t                        dbg_csl_ack_phase;
+    uint32_t                        rx_done_symbol_cnt;
+    union {
+        uint16_t                    saddr;
+        uint32_t                    xaddr[2];
+        uint8_t                     addr[8];
+    } src_addr;
+    lmac154_rxDoneCallback_t        callback[2];
+};
+
+/****************************************************************************
+ * @brief  lmac154 stack index enumeration
+ *
+ ******************************************************************************/
+typedef enum {
+    LMAC154_STACK_1 = 0,  /**< First stack (default for single stack mode) */
+    LMAC154_STACK_2 = 1,  /**< Second stack (for dual stack mode) */
+} lmac154_stack_idx_t;
+
+typedef struct {
+    uint32_t *                      key;
+    uint8_t                         a_data_length;
+    uint8_t                         m_data_length;
+    struct {
+        uint32_t                    ext_addr[2];
+        uint32_t                    frame_cnt;
+        uint8_t                     security_level;
+    }                               nonce;
+    uint32_t *                      a_data;      /* Authentication data (header) */
+    uint32_t *                      m_data;      /* Message data */
+    uint32_t *                      c_data;      /* Encrypted output buffer */
+} lmac154_security_t;
+
+typedef struct {
+    uint32_t                        base_time;
+    uint32_t                        delay_time;
+} lmac154_tx_timing_t;
+
+typedef struct {
+    uint8_t                         csl_retry;
+    uint8_t                         csl_ie_offset;
+    uint16_t                        csl_period;
+    uint32_t                        csl_sample_time;
+    int8_t                          csl_tx_offset_sym_cnt;
+    int8_t                          dbg_csl_drift_tx;
+    uint16_t                        dbg_csl_tx_phase;
+} lmac154_csl_opt_t;
+
+typedef struct __lmac154_txParam_ext {
+    uint32_t *                      pkt;
+    uint32_t                        pkt_length:8;
+    uint32_t                        tx_channel:4;
+    uint32_t                        resume_channel:4;
+    uint32_t                        csma_ca_max_backoff:4;
+    uint32_t                        is_cca:1;
+    uint32_t                        is_ack_required:1;
+    uint32_t                        is_enh_ack_required:1;
+    uint32_t                        is_tx_doing:1;
+    uint32_t                        is_last_tx:1;
+    uint32_t                        is_base_param:1;
+    uint32_t                        is_tx_security:1;
+    uint32_t                        unused:5;
+    uint32_t                        ack_rx_done_symbol_cnt;
+    lmac154_txDoneCallback_t        tx_done_cb;
+    struct __lmac154_txParam_ext *  next;
+
+    lmac154_security_t              sec;
+    lmac154_tx_timing_t             tx_timing;
+    lmac154_csl_opt_t               csl_opt;
+#if CONFIG_LMAC154_DBG
+    uint32_t                        dbg_plat_entry_sym;
+#endif
+} lmac154_txParam_ext_t;
+
+typedef struct __lmac154_txParam {
+    uint32_t *                      pkt;
+    uint32_t                        pkt_length:8;
+    uint32_t                        tx_channel:4;
+    uint32_t                        resume_channel:4;
+    uint32_t                        csma_ca_max_backoff:4;
+    uint32_t                        is_cca:1;
+    uint32_t                        is_ack_required:1;
+    uint32_t                        is_enh_ack_required:1;
+    uint32_t                        is_tx_doing:1;
+    uint32_t                        is_last_tx:1;
+    uint32_t                        is_base_param:1;
+    uint32_t                        unused:6;
+    uint32_t                        ack_rx_done_symbol_cnt;
+    lmac154_txDoneCallback_t        tx_done_cb;
+    struct __lmac154_txParam_ext *  next;
+} lmac154_txParam_t;
+
+/* Frame control constants and macros have been moved to lmac154_frame.h */
+
+/****************************************************************************
+ * @brief  Initialize the hardware module
+ *         Call this function first
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_init(void);
+
+/****************************************************************************
+ * @brief  Enable MAC 15.4 2015 standard feature
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015(bool isEnable);
+
+/****************************************************************************
+ * @brief  Enable MAC 15.4 2015 standard feature with extra configuration
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015Extra(bool isEnable);
+
+/****************************************************************************
+ * @brief  Enable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable1stStack(void);
+
+/****************************************************************************
+ * @brief  Disable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable1stStack(void);
+
+/****************************************************************************
+ * @brief  Enable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable1stStack(void);
+
+/****************************************************************************
+ * @brief  Disable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable1stStack(void);
+
+/****************************************************************************
+ * @brief  Enable second stack for dual stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2ndStack(void);
+
+/****************************************************************************
+ * @brief  Disable second stack for dual stack, which is disable by default
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2ndStack(void);
+
+/****************************************************************************
+ * @brief  Check whether the second stack is enabled
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+uint32_t lmac154_is2ndStackEnabled(void);
+
+/****************************************************************************
+ * @brief  Get whether lmac154 is disabled
+ *
+ * @param  None
+ *
+ * @return 1 for disabled, 0 for enabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isDisabled(void);
+
+/****************************************************************************
+ * @brief  Monitor the hardware state
+ *
+ * @param  monitor_timeout, monitor timeout in ms
+ *
+ * @return monitor result
+ *
+*******************************************************************************/
+int lmac154_monitor(uint32_t monitor_timeout);
+
+/****************************************************************************
+ * @brief  Get the lmac154 interrupt handler for interrupt registration of M154_IRQn
+ *
+ * @param  None
+ *
+ * @return The lmac154 interrupt handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptHandler(void);
+
+/****************************************************************************
+ * @brief  Register rx done event callback for specific stack and get m154 irq handler
+ *
+ * @param  stack_idx, which stack to register (LMAC154_STACK_1 or LMAC154_STACK_2)
+ * @param  stack_rxDoneCallback, frame received callback function
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+bool lmac154_registerEventCallback(lmac154_stack_idx_t stack_idx,
+                                   lmac154_rxDoneCallback_t stack_rxDoneCallback);
+
+/****************************************************************************
+ * @brief  Register rx done event callback and get m154 irq handler
+ *
+ * @param  stack1_rxDoneCallback, frame received with destination panid on stack 1
+ *
+ * @param  stack2_rxDoneCallback, frame received with destination panid on stack 2
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptCallback(void);
+
+/****************************************************************************
+ * @brief  Get the version number
+ *
+ * @param  None
+ *
+ * @return The library version number
+ *
+*******************************************************************************/
+uint32_t lmac154_getVersionNumber(void);
+
+/****************************************************************************
+ * @brief  Get the version number string
+ *
+ * @param  None
+ *
+ * @return The library version number string
+ *
+*******************************************************************************/
+char * lmac154_getVersionString(void);
+
+/****************************************************************************
+ * @brief  Enable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer accepts all frames received from the PHY layer
+ *         Able to receive frames without any IFS but rx sensitivity may be degraded if enhanced_mode = 1
+ *         The MPDU is unavailable in lmac154_rxDoneEvent if ignore_mpdu = 1
+ *
+ * @param  enhanced_mode: 0: standard mode, 1: enhanced mode
+ * @param  ignore_mpdu: 0: read mpdu from registers, 1: do not read mpdu from registers
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxPromiscuousMode(uint8_t enhanced_mode, uint8_t ignore_mpdu);
+
+/****************************************************************************
+ * @brief  Disable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer only accepts frames that pass the address filtering
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxPromiscuousMode(void);
+
+/****************************************************************************
+ * @brief  Get whether rx promiscuous mode is enabled
+ *
+ * @param  None
+ *
+ * @return 1 for enabled; 0 for disabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isRxPromiscuousModeEnabled(void);
+
+/****************************************************************************
+ * @brief  Enable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRx(void);
+
+/****************************************************************************
+ * @brief  try to force enable rx
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_forceEnableRX(void);
+
+/****************************************************************************
+ * @brief  Disable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRx(void);
+
+/****************************************************************************
+ * @brief  Set rx on/off state when idle state
+ *
+ * @param  isRxOnWhenIdle: true is rx on when idle; otherwhile is rx off when idle
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxStateWhenIdle(bool isRxOnWhenIdle);
+
+/****************************************************************************
+ * @brief  Get rx on/off state when idle state
+ *
+ * @param  None
+ *
+ * @return true is rx on when idle; otherwhile is rx off when idle
+ *
+*******************************************************************************/
+bool lmac154_isRxStateWhenIdle(void);
+
+/****************************************************************************
+ * @brief  Set the number of maximum retransmission times (default 0)
+ *         Will perform retransmission in case ack is not received if num > 0
+ *         Will raise lmac154_ackEvent(ack_received = 0) after maximum retransmission times
+ *
+ * @param  num: number of maximum retransmission times
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRetry(uint32_t num);
+
+/****************************************************************************
+ * @brief  Trigger TX
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma: 0: without CSMA, 1: with CSMA
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_triggerTx(uint8_t *DataPtr, uint8_t length, uint8_t csma);
+
+/****************************************************************************
+ * @brief  Trigger TX with base parameter set (no CSL/extended options).
+ *         Wraps lmac154_triggerParamTxExt with is_base_param flag set.
+ *         Must be called within critical section.
+ *
+ * @param  txParam: pointer to lmac154_txParam_t
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTx(lmac154_txParam_t * txParam);
+
+/****************************************************************************
+ * @brief  Trigger TX with extended parameter set.
+ *         Performs CSMA-CA backoff (hardware or software), sets up the MPDU,
+ *         configures CSL IE if applicable, and triggers the radio transmit.
+ *         Must be called within critical section.
+ *
+ * @param  txParam: pointer to lmac154_txParam_ext_t
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTxExt(lmac154_txParam_ext_t * txParam);
+
+/****************************************************************************
+ * @brief  Encrypt packet using AES-CCM with parameters from lmac154_security_t
+ *
+ * Supports frames with or without payload (e.g., enhanced ACK with only header).
+ *
+ * @param  param: pointer to lmac154_security_t containing encryption parameters
+ *                - key: AES key pointer [required]
+ *                - nonce: nonce (ext_addr, frame_cnt, key_id) [required]
+ *                - security_level: security level (determines MIC length) [required]
+ *                - a_data: authentication data (header, plaintext) [required]
+ *                - m_data: message data (plaintext) [optional, can be NULL]
+ *                - c_data: output buffer for encrypted message + MIC [required]
+ *                - a_data_length: length of authentication data [required]
+ *                - m_data_length: length of message data (0 if no payload) [optional]
+ *
+ * @return Encrypted message length + MIC length on success (if m_data_length=0, returns MIC length only),
+ *         negative error code on failure
+ *
+ *******************************************************************************/
+int32_t lmac154_encryptPacket(lmac154_security_t * param);
+
+/****************************************************************************
+ * @brief  Write TX ack frame to mpdu buffer to send in lmac154_receivedEvent
+ *         with isEnhAckExpected true.
+ *
+ * @param  ack_frame: pointer to data buffer of ack frame
+ * @param  ack_frame_length: data length in bytes
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_writeTxAckFrame(uint8_t *ack_frame, int ack_frame_length);
+
+/****************************************************************************
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerParamTx
+ *         is called with time specified
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 1 is selected
+ *
+*******************************************************************************/
+uint32_t lmac154_isTriggerTimeSelected(void);
+
+/****************************************************************************
+ * @brief  Run tx continuous modulation (PRBS15 pattern)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCM(void);
+
+#if defined(BL702) || defined(BL702L)
+/****************************************************************************
+ * @brief  Run tx continuous wave (single tone)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCW(void);
+#endif
+
+/****************************************************************************
+ * @brief  Reset tx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetTx(void);
+
+/****************************************************************************
+ * @brief  Reset rx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetRx(void);
+
+/****************************************************************************
+ * @brief  Set the channel (default LMAC154_CHANNEL_11)
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setChannel(lmac154_channel_t ch_ind);
+
+/****************************************************************************
+ * @brief  Get the channel
+ *
+ * @param  None
+ *
+ * @return The channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+*******************************************************************************/
+lmac154_channel_t lmac154_getChannel(void);
+
+/****************************************************************************
+ * @brief  Get RSSI in dBm
+ *
+ * @param  None
+ *
+ * @return RSSI in dBm
+ *
+*******************************************************************************/
+int lmac154_getRSSI(void);
+
+/****************************************************************************
+ * @brief  Get LQI
+ *
+ * @param  None
+ *
+ * @return LQI
+ *
+*******************************************************************************/
+int lmac154_getLQI(void);
+
+/****************************************************************************
+ * @brief  Get SFD correlation
+ *
+ * @param  None
+ *
+ * @return SFD correlation
+ *
+*******************************************************************************/
+uint8_t lmac154_getSFDCorrelation(void);
+
+/****************************************************************************
+ * @brief  Get the frequency offset in Hz
+ *
+ * @param  None
+ *
+ * @return The frequency offset in Hz
+ *
+*******************************************************************************/
+int lmac154_getFrequencyOffset(void);
+
+/****************************************************************************
+ * @brief  Set country code for tx power adjustment
+ *
+ * @param  country_code: country code, for example: CN
+ *
+ * @return true, if country code is valid.
+ *
+*******************************************************************************/
+bool lmac154_setCountryCode(const char * country_code);
+
+/****************************************************************************
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPower(lmac154_tx_power_t power_dbm);
+
+/****************************************************************************
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @param country_code: country code, for example: CN
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPowerWithPowerLimit(lmac154_tx_power_t power_dbm, lmac154_channel_t ch_ind, const char *country_code);
+
+/****************************************************************************
+ * @brief  Get tx power
+ *
+ * @param  None
+ *
+ * @return tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+*******************************************************************************/
+lmac154_tx_power_t lmac154_getTxPower(void);
+
+/****************************************************************************
+ * @brief  Set tx data rate (default LMAC154_DATA_RATE_250K)
+ *         The maximum tx mpdu length is 127 bytes for 250kbps tx data rate, and 255 bytes for others
+ *
+ * @param  rate: LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxDataRate(lmac154_data_rate_t rate);
+
+/****************************************************************************
+ * @brief  Enable auto rx data rate (default disabled)
+ *         The maximum rx mpdu length is 127 bytes for 250kbps rx data rate, and 255 bytes for others
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAutoRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Disable auto rx data rate (default disabled)
+ *         The rx data rate is 250kbps, and the maximum rx mpdu length is 127 bytes
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAutoRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Get rx data rate
+ *
+ * @param  None
+ *
+ * @return LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+*******************************************************************************/
+lmac154_data_rate_t lmac154_getRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Set CCA mode (default LMAC154_CCA_MODE_ED_AND_CS)
+ *
+ * @param  mode: LMAC154_CCA_MODE_ED, LMAC154_CCA_MODE_CS, LMAC154_CCA_MODE_ED_AND_CS, or LMAC154_CCA_MODE_ED_OR_CS
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCCAMode(lmac154_cca_mode_t mode);
+
+/****************************************************************************
+ * @brief  Set CCA ED threshold (default -71dBm)
+ *
+ * @param  threshold: ED threshold ranging from -122 to 5 in dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEDThreshold(int threshold);
+
+/****************************************************************************
+ * @brief  Get CCA ED threshold
+ *
+ * @param  None
+ *
+ * @return ED threshold
+ *
+*******************************************************************************/
+int lmac154_getEDThreshold(void);
+
+/****************************************************************************
+ * @brief  Run CCA
+ *
+ * @param  rssi: rssi output ranging from -122 to 5 in dBm
+ *
+ * @return CCA result: 0: channel idle, 1: channel busy
+ *
+*******************************************************************************/
+uint8_t lmac154_runCCA(int *rssi);
+
+/****************************************************************************
+ * @brief  Set PAN ID (default 0x4321)
+ *
+ * @param  pid: PAN ID
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setPanId(uint16_t pid);
+void lmac154_set2ndPanId(uint16_t pid);
+
+/****************************************************************************
+ * @brief  Get PAN ID
+ *
+ * @param  None
+ *
+ * @return PAN ID
+ *
+*******************************************************************************/
+uint16_t lmac154_getPanId(void);
+uint16_t lmac154_get2ndPanId(void);
+
+/****************************************************************************
+ * @brief  Set 16-bit short address (default 0x0000)
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setShortAddr(uint16_t sadr);
+void lmac154_set2ndShortAddr(uint16_t sadr);
+
+/****************************************************************************
+ * @brief  Get 16-bit short address
+ *
+ * @param  None
+ *
+ * @return 16-bit short address
+ *
+*******************************************************************************/
+uint16_t lmac154_getShortAddr(void);
+uint16_t lmac154_get2ndShortAddr(void);
+
+/****************************************************************************
+ * @brief  Set 64-bit long address (default 0xACDE4800_00000002)
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setLongAddr(uint8_t *ladr);
+void lmac154_set2ndLongAddr(uint8_t *ladr);
+
+/****************************************************************************
+ * @brief  Get 64-bit long address
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getLongAddr(uint8_t *ladr);
+void lmac154_get2ndLongAddr(uint8_t *ladr);
+
+/****************************************************************************
+ * @brief  Enable frame type filtering (default disabled)
+ *         Will only receive specified frame types
+ *
+ * @param  frame_types: any combination of LMAC154_FRAME_TYPE_XXX (BEACON, DATA, ACK, or CMD), via bitwise OR ('|') operation
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableFrameTypeFiltering(uint8_t frame_types);
+
+/****************************************************************************
+ * @brief  Disable frame type filtering (default disabled)
+ *         Will receive all valid frame types (BEACON, DATA, ACK, or CMD)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableFrameTypeFiltering(void);
+
+/****************************************************************************
+ * @brief  Set rx reject policy
+ *
+ * @param policy : enum lmac154_rx_reject_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxRejectPolicy(lmac154_rx_reject_policy_t policy);
+
+/****************************************************************************
+ * @brief  Get rx reject policy
+ *
+ * @param None
+ *
+ * @return Rx reject policy
+ *
+*******************************************************************************/
+lmac154_rx_reject_policy_t lmac154_getRxRejectPolicy(void);
+
+/****************************************************************************
+ * @brief  set rx accept policy
+ *
+ *
+ * @param policy : enum lmac154_rx_accept_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxAcceptPolicy(lmac154_rx_accept_policy_t policy);
+
+/****************************************************************************
+ * @brief  get rx accept policy
+ *
+ *
+ * @param None
+ *
+ * @return lmac154_rx_accept_policy : enum lmac154_rx_accept_policy_t
+ *
+*******************************************************************************/
+lmac154_rx_accept_policy_t lmac154_getRxAcceptPolicy(void);
+
+#ifdef BL702
+/****************************************************************************
+ * @brief  Set external PA
+ *         Restriction: txpin % 5 != rxpin % 5
+ *
+ * @param  txpin: tx pin ranging from 0 to 31
+ * @param  rxpin: rx pin ranging from 0 to 31
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setExtPA(uint32_t txpin, uint32_t rxpin);
+#endif
+
+/****************************************************************************
+ * @brief  Get RF state
+ *
+ * @param  None
+ *
+ * @return LMAC154_RF_STATE_RX, LMAC154_RF_STATE_RX_DOING, LMAC154_RF_STATE_TX, or LMAC154_RF_STATE_IDLE
+ *
+*******************************************************************************/
+lmac154_rf_state_t lmac154_getRFState(void);
+
+/****************************************************************************
+ * @brief  Enable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableCoex(void);
+
+/****************************************************************************
+ * @brief  Disable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableCoex(void);
+
+/****************************************************************************
+ * @brief  Check if coexistence is enabled
+ *
+ * @param  None
+ *
+ * @return true if coexistence is enabled, false otherwise
+ *
+ *******************************************************************************/
+bool lmac154_isCoexEnabled(void);
+
+/****************************************************************************
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCoexPriority(bool is_rx_on_after_rx_abort_enable, uint32_t tx_priority,
+    uint32_t rx_unicast_priority, uint32_t rx_sfd_priority, uint32_t rx_idle_priority);
+
+/****************************************************************************
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getCoexPriority(bool * is_rx_on_after_rx_abort_enable, uint32_t * tx_priority,
+    uint32_t * rx_unicast_priority, uint32_t * rx_sfd_priority, uint32_t * rx_idle_priority);
+
+/****************************************************************************
+ * @brief  Enable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableTxAbortInt(void);
+
+/****************************************************************************
+ * @brief  Disable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableTxAbortInt(void);
+
+/****************************************************************************
+ * @brief  Enable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableHwAutoTxAck(void);
+
+/****************************************************************************
+ * @brief  Disable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableHwAutoTxAck(void);
+
+/****************************************************************************
+ * @brief  Get whether hardware auto transmission of ack frame is enabled
+ *
+ * @param  None
+ *
+ * @return ture, enabled
+ *
+*******************************************************************************/
+bool lmac154_isHwAutoTxAckEnabled(void);
+
+/****************************************************************************
+ * @brief  Enable lmac154_ackEvent (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAckEvent(void);
+
+/****************************************************************************
+ * @brief  Disable lmac154_ackEvent (default enabled)
+ *         Will raise lmac154_rxDoneEvent instead when ack is received
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAckEvent(void);
+
+/****************************************************************************
+ * @brief  Enable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Disable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Enable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxMHREvent(void);
+
+/****************************************************************************
+ * @brief  Disable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxMHREvent(void);
+
+/****************************************************************************
+ * @brief  Enable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxSecMHREvent(void);
+
+/****************************************************************************
+ * @brief  Disable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxSecMHREvent(void);
+
+/****************************************************************************
+ * @brief  Enable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableReqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Disable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableReqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Get the receiving or received mpdu length in bytes (crc included)
+ *
+ * @param  None
+ *
+ * @return The receiving or received mpdu length
+ *
+*******************************************************************************/
+uint8_t lmac154_getRxLength(void);
+
+/****************************************************************************
+ * @brief  Read rx data (crc not included)
+ *
+ * @param  buf: pointer to data buffer
+ * @param  offset: data offset ranging from 0 to 252 in bytes
+ * @param  len: data length ranging from 1 to 253-offset in bytes
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxData(uint8_t *buf, uint8_t offset, uint8_t len);
+
+/****************************************************************************
+ * @brief  Read rx crc
+ *
+ * @param  crc: byte array to carry rx crc
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxCrc(uint8_t crc[2]);
+
+/****************************************************************************
+ * @brief  Set the maximum wait time for ack frame (default 864us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setAckWaitTime(uint16_t time_us);
+
+/****************************************************************************
+ * @brief  Get the maximum wait time for imm-ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getAckWaitTime(void);
+
+/****************************************************************************
+ * @brief  Set the maximum wait time for enh-ack ack frame (default 1500us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEnhAckWaitTime(uint16_t time_us);
+
+/****************************************************************************
+ * @brief  Get the maximum wait time for enh-ack ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getEnhAckWaitTime(void);
+
+/****************************************************************************
+ * @brief  Set the maximum and minimum CSMA-CA backoff exponent
+ *
+ * @param  max_be: maximum BE ranging from 3 to 8, default 5
+ * @param  min_be: minimum BE ranging from 0 to max_be, default 3
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setBE(uint8_t max_be, uint8_t min_be);
+
+/****************************************************************************
+ * @brief  Set maximum CSMA backoff
+ *
+ * @param  maxBackoff: maximum CSMA backoff
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setMaxCsmaBackoff(uint8_t maxBackoff);
+
+/****************************************************************************
+ * @brief  Set tx-rx transition time
+ *
+ * @param  time: us
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRxTransTime(uint8_t timeInUs);
+
+/****************************************************************************
+ * @brief  Enable Rx filtering (default enabled)
+ *         Will only receive frames that pass crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxFiltering(void);
+
+/****************************************************************************
+ * @brief  Disable rx filtering (default enabled)
+ *         Will receive all frames ignoring crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxFiltering(void);
+
+/****************************************************************************
+ * @brief  Enable/Disable rx filtering (default enabled) for dual stacks
+ *         Will receive all frames ignoring crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxFiltering(bool is_enable);
+
+uint64_t lmac154_get_rx_start_timestamp(void);
+uint64_t lmac154_get_rx_done_timestamp(void);
+uint64_t lmac154_get_tx_done_timestamp(void);
+
+#if defined (BL702) || defined (BL702L) || defined (BL616)
+bool lmac154_fptSetMaxNum(uint32_t shortAddrNum, uint32_t longAddrNum);
+#endif
+
+/****************************************************************************
+ * @brief  Run AES CCM
+ *
+ * @param  mode: LMAC154_AES_MODE_ENCRYPT or LMAC154_AES_MODE_DECRYPT
+ * @param  a_data: pointer to additional authentication data buffer
+ * @param  a_len: length of additional authentication data in bytes
+ * @param  nonce: pointer to 13-byte nonce buffer
+ * @param  key: pointer to 4-word key buffer
+ * @param  mic_len: LMAC154_MIC_LEN_4, LMAC154_MIC_LEN_8, LMAC154_MIC_LEN_12, or LMAC154_MIC_LEN_16
+ * @param  mic: pointer to mic buffer
+ * @param  input_data: pointer to input data buffer
+ * @param  output_data: pointer to output data buffer
+ * @param  len: length of input data in bytes
+ *
+ * @return The error code
+ *
+*******************************************************************************/
+lmac154_aes_status_t lmac154_runAESCCM(lmac154_aes_mode_t mode,
+                                       const uint8_t *a_data,
+                                       uint8_t a_len,
+                                       const uint8_t *nonce,
+                                       const uint32_t *key,
+                                       lmac154_aes_mic_len_t mic_len,
+                                       uint32_t *mic,
+                                       const uint32_t *input_data,
+                                       uint32_t *output_data,
+                                       uint8_t len);
+
+/* hardware frame pending table (256 bytes) */
+/* shared by short addresses and long addresses (supports up to 128 short addresses or 32 long addresses or mixed) */
+/* used by hardware to set the frame pending bit of hw auto tx ack */
+/* if the address is not found in the table (e.g. not set or removed), the frame pending bit of hw auto tx ack is 1 */
+
+/****************************************************************************
+ * @brief  Add (or update) the key-value pair {sadr: pending} to (in) the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetShortAddrPending(uint16_t sadr, uint8_t pending);
+
+/****************************************************************************
+ * @brief  Add (or update) the key-value pair {ladr: pending} to (in) the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetLongAddrPending(uint32_t *xaddr, uint8_t pending);
+
+/****************************************************************************
+ * @brief  Get the corresponding frame pending bit of the short address in the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetShortAddrPending(uint16_t sadr, uint8_t *pending);
+
+/****************************************************************************
+ * @brief  Get the corresponding frame pending bit of the long address in the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetLongAddrPending(uint32_t *xaddr, uint8_t *pending);
+
+/****************************************************************************
+ * @brief  Remove the key-value pair {sadr: pending} from the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveShortAddr(uint16_t sadr);
+
+/****************************************************************************
+ * @brief  Remove the key-value pair {ladr: pending} from the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveLongAddr(uint32_t *ladr);
+
+/****************************************************************************
+ * @brief  Get short address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetShortAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************
+ * @brief  Get long address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetLongAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************
+ * @brief  Set frame pending bit according to frame pending table, or force to set to 1
+ *
+ * @param  force: 0: set according to frame pending table (default), 1: force to set to 1
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptForcePending(uint8_t force);
+
+/****************************************************************************
+ * @brief  Clear the frame pending table
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptClear(void);
+
+/****************************************************************************
+ * @brief  Print the frame pending table using specified print function
+ *
+ * @param  print_func: user specified print function
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptDump(int print_func(const char *fmt, ...));
+
+/* functions below are callback functions running in the interrupt context */
+/* should be implemented by user if needed */
+
+/****************************************************************************
+ * @brief  Tx Done Event
+ *         Will be raised after calling lmac154_triggerTx
+ *
+ * @param  tx_status: LMAC154_TX_STATUS_XXX (TX_FINISHED, CSMA_FAILED, TX_ABORTED, or HW_ERROR)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_txDoneEvent(lmac154_tx_status_t tx_status);
+
+/****************************************************************************
+ * @brief  Ack Event
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  frame_pending: frame pending bit in ack frame
+ * @param  seq_num: sequence number in ack frame
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackEvent(uint8_t ack_received, uint8_t frame_pending, uint8_t seq_num);
+
+/****************************************************************************
+ * @brief  Ack Event with ack frame
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  rx_buf: pointer to the ack frame buffer
+ * @param  len: ACK frame length
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackFrameEvent(uint8_t ack_received, uint8_t *rx_buf, uint8_t len);
+
+/****************************************************************************
+ * @brief  Rx Done Event
+ *         Will be raised when a frame is received on lmac154_getInterruptHandler used
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received mpdu length in bytes (crc included)
+ * @param  crc_fail: 0: crc pass, 1: crc fail
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxDoneEvent(uint8_t *rx_buf, uint8_t rx_len, uint32_t crc_fail);
+
+/****************************************************************************
+ * @brief  Rx Start Event
+ *         Will be raised when rx on MAC sublayer starts
+ *         lmac154_getRxLength is available because it is obtained from PHY layer
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Hardware auto tx ack done event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_hwAutoTxAckDoneEvent(void);
+
+/****************************************************************************
+ * @brief  A 2015 version unicast packet received and enh-ack is required to respond
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_reqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+/****************************************************************************
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxSecMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+#endif

--- a/include/bouffalolab/bl61x/lmac154/lmac154_fpt.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154_fpt.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FPT_H__
+#define __LMAC154_FPT_H__
+
+
+typedef enum {
+    LMAC154_FPT_DATAREQ             = 0,
+    LMAC154_FPT_DATAREQ_DATA        = 1,
+    LMAC154_FPT_ANY                 = 2
+} lmac154_fptMode_t;
+
+typedef enum {
+    LMAC154_FPT_RESULT_NONE         = 0,
+    LMAC154_FPT_RESULT_FALSE        = 1,
+    LMAC154_FPT_RESULT_TRUE         = 2,
+    LMAC154_FPT_RESULT_BUSY         = 3
+} lmac154_fptResult_t;
+
+void lmac154_setFramePendingSourceMatch(bool isEnable);
+
+/****************************************************************************//**
+ * @brief  Set frame pending table mode
+ *
+ * @param  mode:
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingMode(lmac154_fptMode_t mode);
+
+/****************************************************************************//**
+ * @brief  Get frame pending table mode
+ *
+ * @param  None
+ *
+ * @return lmac154_fptMode_t
+ *
+*******************************************************************************/
+lmac154_fptMode_t lmac154_getFramePendingMode(void);
+
+/****************************************************************************//**
+ * @brief  Get frame pending table result when receive a packet
+ *
+ * @param  tout: timeout to do frame pending table search
+ *
+ * @param  isFramePended: whether frame pending is set for searched on received packet
+ *
+ * @return int: return the index of neighbor table if matched; else, return -1
+ *
+*******************************************************************************/
+int lmac154_framePendingResult(uint32_t tout, bool * isFramePended);
+
+/****************************************************************************//**
+ * @brief  Set frame pending bit result if neighbor search fails
+ *
+ * @param  bFramePending, frame pending bit, true by default.
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingBitIfNeighborSearchFails(bool bFramePending);
+
+/****************************************************************************//**
+ * @brief  Get frame pending bit result if neighbor search fails
+ *
+ * @param  None
+ *
+ * @return True, if neighbor search fails.
+ *
+*******************************************************************************/
+bool lmac154_getFramePendingBitIfNeighborSearchFails(void);
+
+#endif

--- a/include/bouffalolab/bl61x/lmac154/lmac154_fpt.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154_fpt.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FPT_H__
+#define __LMAC154_FPT_H__
+
+typedef enum {
+    LMAC154_FPT_DATAREQ             = 0,
+    LMAC154_FPT_DATAREQ_DATA        = 1,
+    LMAC154_FPT_ANY                 = 2
+} lmac154_fptMode_t;
+
+typedef enum {
+    LMAC154_FPT_RESULT_NONE         = 0,
+    LMAC154_FPT_RESULT_FALSE        = 1,
+    LMAC154_FPT_RESULT_TRUE         = 2,
+    LMAC154_FPT_RESULT_BUSY         = 3
+} lmac154_fptResult_t;
+
+void lmac154_setFramePendingSourceMatch(bool isEnable);
+
+/****************************************************************************
+ * @brief  Set frame pending table mode
+ *
+ * @param  mode:
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingMode(lmac154_fptMode_t mode);
+
+/****************************************************************************
+ * @brief  Get frame pending table mode
+ *
+ * @param  None
+ *
+ * @return lmac154_fptMode_t
+ *
+*******************************************************************************/
+lmac154_fptMode_t lmac154_getFramePendingMode(void);
+
+/****************************************************************************
+ * @brief  Get frame pending table result when receive a packet
+ *
+ * @param  tout: timeout to do frame pending table search
+ *
+ * @param  isFramePended: whether frame pending is set for searched on received packet
+ *
+ * @return int: return the index of neighbor table if matched; else, return -1
+ *
+*******************************************************************************/
+int lmac154_framePendingResult(uint32_t tout, bool * isFramePended);
+
+#if defined BL618DG
+/****************************************************************************
+ * @brief  Set frame pending bit result if neighbor search fails
+ *
+ * @param  bFramePending, frame pending bit, true by default.
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingBitIfNeighborSearchFails(bool bFramePending);
+
+/****************************************************************************
+ * @brief  Get frame pending bit result if neighbor search fails
+ *
+ * @param  None
+ *
+ * @return True, if neighbor search fails.
+ *
+*******************************************************************************/
+bool lmac154_getFramePendingBitIfNeighborSearchFails(void);
+#endif
+#endif

--- a/include/bouffalolab/bl61x/lmac154/lmac154_frame.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154_frame.h
@@ -1,0 +1,550 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FRAME_H__
+#define __LMAC154_FRAME_H__
+
+/****************************************************************************
+ * @file lmac154_frame.h
+ * @brief IEEE 802.15.4 Frame Parsing and Analysis Module
+ ******************************************************************************/
+
+/*============================================================================
+ * Frame Control Field Definitions
+ *============================================================================*/
+
+/* Frame Type */
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK       (7)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_BEACON     (0)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA       (1)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK        (2)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD        (3)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP        (5)
+
+/* Security and Pending */
+#define LMAC154_FRAME_SECURITY_MASK                 (1 << 3)
+#define LMAC154_FRAME_FRAME_PENDING_MASK            (1 << 4)
+#define LMAC154_FRAME_ACK_REQUEST_MASK              (1 << 5)
+#define LMAC154_FRAME_PANID_COMPRESSION             (1 << 6)
+#define LMAC154_FRAME_SEQ_SUPPRESSION_MASK          (1 << 8)
+#define LMAC154_FRAME_IE_MASK                       (1 << 9)
+
+/* Addressing Fields */
+#define LMAC154_FRAME_ADDR_DEST_NONE                (0 << 10)
+#define LMAC154_FRAME_ADDR_DEST_SHORT               (2 << 10)
+#define LMAC154_FRAME_ADDR_DEST_EXT                 (3 << 10)
+#define LMAC154_FRAME_ADDR_DEST_MASK                (3 << 10)
+
+#define LMAC154_FRAME_VERSION_MASK                  (3 << 12)
+#define LMAC154_FRAME_VERSION_2003                  (0 << 12)
+#define LMAC154_FRAME_VERSION_2006                  (1 << 12)
+#define LMAC154_FRAME_VERSION_2015                  (2 << 12)
+
+#define LMAC154_FRAME_ADDR_SRC_NONE                 (0 << 14)
+#define LMAC154_FRAME_ADDR_SRC_SHORT                (2 << 14)
+#define LMAC154_FRAME_ADDR_SRC_EXT                  (3 << 14)
+#define LMAC154_FRAME_ADDR_SRC_MASK                 (3 << 14)
+
+/* MPP (Multi-Purpose Protocol) Frame Specific */
+#define LMAC154_FRAME_MPP_LONG_FRAME_BIT            (1 << 3)
+#define LMAC154_FRAME_MPP_SECURITY_BIT              (1 << 9)
+#define LMAC154_FRAME_MPP_ACK_REQ                   (1 << 14)
+
+/* Auxiliary Security Header */
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_MASK          (3 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_0             (0 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_1             (1 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_2             (2 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_3             (3 << 3)
+
+/*============================================================================
+ * Frame Check Macros
+ *============================================================================*/
+
+/* Frame Type Check */
+#define LMAC154_FRAME_IS_BEACON(x)                  (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_BEACON)
+#define LMAC154_FRAME_IS_DATA(x)                    (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA)
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+#define LMAC154_FRAME_IS_CMD(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD)
+#define LMAC154_FRAME_IS_MPP(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP)
+
+/* Security Check */
+#define LMAC154_FRAME_IS_NORMAL_SECURITY(x)         ((x & LMAC154_FRAME_SECURITY_MASK) == LMAC154_FRAME_SECURITY_MASK)
+#define LMAC154_FRAME_IS_MPP_LONG_FRAME(x)          ((x & LMAC154_FRAME_MPP_LONG_FRAME_BIT) == LMAC154_FRAME_MPP_LONG_FRAME_BIT)
+#define LMAC154_FRAME_IS_MPP_SECURITY(x)            (LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_SECURITY_BIT) == LMAC154_FRAME_MPP_SECURITY_BIT)
+#define LMAC154_FRAME_IS_SECURITY_ENABLED(x)        (LMAC154_FRAME_IS_MPP(x) ? LMAC154_FRAME_IS_MPP_SECURITY(x) : LMAC154_FRAME_IS_NORMAL_SECURITY(x))
+
+/* ACK and Pending Check */
+#define LMAC154_FRAME_IS_ACK_REQ(x)                 (((x) & LMAC154_FRAME_ACK_REQUEST_MASK) == LMAC154_FRAME_ACK_REQUEST_MASK)
+#define LMAC154_FRAME_IS_FRAME_PENDED(x)            ((x) & LMAC154_FRAME_FRAME_PENDING_MASK)
+#define LMAC154_FRAME_IS_PANID_COMPRESSED(x)        (((x) & LMAC154_FRAME_PANID_COMPRESSION) == LMAC154_FRAME_PANID_COMPRESSION)
+#define LMAC154_FRAME_IS_SEQ_SUPPRESS(x)            (((x) & LMAC154_FRAME_SEQ_SUPPRESSION_MASK) == LMAC154_FRAME_SEQ_SUPPRESSION_MASK)
+
+/* Enhanced ACK Check */
+#define LMAC154_FRAME_IS_MPP_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP(x) && LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_ACK_REQ) == LMAC154_FRAME_MPP_ACK_REQ)
+#define LMAC154_FRAME_IS_ENH_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP_ACK_REQ(x) || (LMAC154_FRAME_IS_ACK_REQ(x) && LMAC154_FRAME_IS_FRAME_2015(x)))
+#define LMAC154_FRAME_IS_IMM_ACK_REQ(x)             (LMAC154_FRAME_IS_ACK_REQ(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* Frame Version Check */
+#define LMAC154_FRAME_IS_FRAME_2015(x)              (((x) & LMAC154_FRAME_VERSION_MASK) == LMAC154_FRAME_VERSION_2015)
+#define LMAC154_FRAME_IS_IE_EXIST(x)                (((x) & LMAC154_FRAME_IE_MASK) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* ACK Type Check */
+#define LMAC154_FRAME_IS_IMM_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_ENH_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* Address Type Extraction */
+#define LMAC154_FRAME_GET_DST_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_DEST_MASK)
+#define LMAC154_FRAME_GET_SRC_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_SRC_MASK)
+
+typedef struct {
+    uint8_t sec_lvl:3;
+    uint8_t key_id_mode:2;
+    uint8_t frame_counter_sup:1;
+    uint8_t asn_in_nonce:1;
+    uint8_t reserved:1;
+    uint8_t frame_cnt[4];
+    uint8_t key_id[8];
+} __packed lmac154_aux_hdr_t;
+
+typedef struct {
+    uint16_t length:7;
+    uint16_t element_id:8;
+    uint16_t type:1;
+} __packed lmac154_ie_hdr_t;
+
+typedef union {
+    struct {
+        lmac154_ie_hdr_t hdr;
+        uint16_t phase;
+        uint16_t period;
+    } __packed bf;
+    uint8_t bytes[6];
+} __packed lmac154_ie_csl_t;
+
+#define LMAC154_LIFS                    40
+#define LMAC154_SIFS                    12
+#define LMAC154_AIFS                    LMAC154_SIFS
+#define LMAC154_SIFS_MAX_FRAME_SIZE     18
+#define LMAC154_TURNAROUND              12
+#define LMAC154_PKT_MAX_LEN             127
+#define LMAC154_PREAMBLE_LEN            8
+#define LMAC154_SHR_LEN                 10
+#define LMAC154_US_PER_SYMBOL           16
+#define LMAC154_US_PER_SYMBOL_BITS      4
+
+#define LMAC154_CSMA_CA_MIN_BE          3
+#define LMAC154_CSMA_CA_MAX_BE          5
+#define LMAC154_CSMA_CA_MAX_BACKOFF     4
+
+/* Key ID Mode definitions */
+#define LMAC154_KEY_ID_MODE_0                 0
+#define LMAC154_KEY_ID_MODE_1                 1
+#define LMAC154_KEY_ID_MODE_2                 2
+#define LMAC154_KEY_ID_MODE_3                 3
+#define LMAC154_KEY_ID_MODE_4                 4
+
+/* Key ID lengths for different modes */
+#define LMAC154_KEY_ID_LEN_MODE_0             0
+#define LMAC154_KEY_ID_LEN_MODE_1             1
+#define LMAC154_KEY_ID_LEN_MODE_2             5
+#define LMAC154_KEY_ID_LEN_MODE_3             8
+#define LMAC154_KEY_ID_LEN_MODE_4_MIN         0
+#define LMAC154_KEY_ID_LEN_MODE_4_MAX         9
+
+/* IE (Information Element) Definitions */
+#define LMAC154_IE_TERmination2_ID              0x7f
+#define LMAC154_IE_CSL_ID                       0x1a
+
+/* Thread Vendor IE Definitions */
+#define LMAC154_IE_VENDOR_ID                    0x00
+#define LMAC154_IE_THREAD_VENDOR_ID             0x00
+#define LMAC154_IE_THREAD_ENH_ACK_PROBING_IE_ID 0x00
+#define LMAC154_IE_THREAD_HDR_SIZE              4
+
+/**
+ * @brief  32-bit optimized MAC Header parser.
+ * @note   Assumes 'pr' (buffer start) is 32-bit aligned.
+ * Uses single-word access to minimize bus cycles and branch mispredictions.
+ * * @param pr           Pointer to the start of the MAC frame (FCF).
+ * @param a_dest_panid Output pointer to Destination PAN ID.
+ * @param a_dest_sa    Output pointer to Destination Short Address.
+ * @param a_dest_xa    Output pointer to Destination Extended Address.
+ * @param a_src_sa     Output pointer to Source Short Address.
+ * @param a_src_xa     Output pointer to Source Extended Address.
+ */
+static inline uint32_t lmac154_parse_mhr(uint8_t *pr, uint8_t **a_dest_panid, uint8_t **a_dest_sa,
+                                 uint8_t **a_dest_xa, uint8_t **a_src_sa, uint8_t **a_src_xa)
+{
+    /* 1. Single 32-bit load to fetch FCF, Seq, and the start of Dest PAN ID.
+     * This is significantly faster than multiple 8-bit loads on 32-bit architectures. */
+    uint32_t head = *(const uint32_t *)pr;
+    uint32_t fcf  = head & 0xFFFF;
+
+    /* Initial offset: FCF(2) + Sequence Number(1) = 3 */
+    uint32_t offset = 3;
+
+    /* Extract Address Modes and PAN ID Compression bit via bit-shifting */
+    uint32_t dst_mode  = (fcf >> 10) & 0x03;
+    uint32_t src_mode  = (fcf >> 14) & 0x03;
+    uint32_t pan_comp  = (fcf >> 6)  & 0x01;
+
+    /* 2. Parse Destination Address Field (PAN ID + Address) */
+    if (dst_mode) {
+        /* Map Mode to length: Mode 2 (Short) -> 2 bytes, Mode 3 (Ext) -> 8 bytes.
+         * Using a ternary here allows compilers to use CMOV (conditional move)
+         * instructions to avoid pipeline stalls. */
+        uint32_t dst_addr_len = (dst_mode == 3) ? 8 : 2;
+
+        /* Destination PAN ID always follows Sequence Number at offset 3 */
+        *a_dest_panid = pr + 3;
+
+        /* Assign address pointers based on mode. Dest Addr starts at offset 5. */
+        if (dst_mode == 2) {
+            *a_dest_sa = pr + 5;
+        } else {
+            *a_dest_xa = pr + 5;
+        }
+
+        /* Update offset: 3 (FCF+Seq) + 2 (PAN) + AddrLength */
+        offset = 5 + dst_addr_len;
+    }
+
+    /* 3. Source PAN ID Compression Logic (Standard 2003/2006/2015 common subset).
+     * If compression bit is 0, a 2-byte Source PAN ID exists before the Source Addr. */
+    if (!pan_comp) {
+        offset += 2;
+    }
+
+    /* 4. Parse Source Address Field */
+    if (src_mode == 2) {
+        /* Source Short Address (2 bytes) */
+        *a_src_sa = pr + offset;
+    } else if (src_mode == 3) {
+        /* Source Extended Address (8 bytes) */
+        *a_src_xa = pr + offset;
+    }
+
+    return offset;
+}
+
+/**
+ * lmac154_parse_mhr_2015 - Strict MHR parser based on 802.15.4-2015 Table 7-2
+ * @pr: Pointer to frame start (MUST be 32-bit aligned)
+ * ... (output pointers)
+ *
+ * Returns the total length of the MHR in bytes.
+ */
+static inline uint32_t lmac154_parse_mhr_2015(uint8_t *pr,
+                       uint8_t **a_dest_panid, uint8_t **a_dest_sa,
+                       uint8_t **a_dest_xa, uint8_t **a_src_panid,
+                       uint8_t **a_src_sa, uint8_t **a_src_xa)
+{
+    uint32_t head = *(const uint32_t *)pr;
+    uint16_t fcf = (uint16_t)(head & 0xffff);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+    uint32_t offset;
+    bool has_dst_pan = false;
+    bool has_src_pan = false;
+
+    /* 1. Sequence Number Suppression (Version 2 feature) */
+    offset = (fcf & (1 << 8)) ? 2 : 3;
+
+    /* 2. Strict Table 7-2 Logic Implementation */
+    if (dst_mode == 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 1);
+    } else if (dst_mode > 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 0);
+    } else if (dst_mode == 0 && src_mode > 0) {
+        has_src_pan = (pan_comp == 0);
+    } else if (dst_mode == 3 && src_mode == 3) {
+        /* Extended <-> Extended: Row 7 & 8 */
+        has_dst_pan = (pan_comp == 0);
+        has_src_pan = false;
+    } else {
+        /* Mixed or Short <-> Short: Row 9-14 */
+        if (pan_comp == 0) {
+            has_dst_pan = true;
+            has_src_pan = true;
+        } else {
+            has_dst_pan = true;
+            has_src_pan = false;
+        }
+    }
+
+    /* 3. Extract Destination Fields */
+    if (has_dst_pan) {
+        *a_dest_panid = pr + offset;
+        offset += 2;
+    }
+
+    if (dst_mode == 2) {
+        *a_dest_sa = pr + offset;
+        offset += 2;
+    } else if (dst_mode == 3) {
+        *a_dest_xa = pr + offset;
+        offset += 8;
+    }
+
+    /* 4. Extract Source Fields */
+    if (has_src_pan) {
+        *a_src_panid = pr + offset;
+        offset += 2;
+    }
+
+    if (src_mode == 2) {
+        *a_src_sa = pr + offset;
+        offset += 2;
+    } else if (src_mode == 3) {
+        *a_src_xa = pr + offset;
+        offset += 8;
+    }
+
+    return offset;
+}
+
+/**
+ * lmac154_get_mhr_len - MHR length for 802.15.4-2003/2006
+ * @pkt: Pointer to frame start
+ */
+static inline uint32_t lmac154_get_mhr_len(const uint8_t *pkt)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+    uint32_t pos = 3; /* FCF(2) + Seq(1), Legacy always has Seq */
+
+    /* Destination Field */
+    if (dst_mode) {
+        pos += 2; /* Destination PAN ID always present if DstMode > 0 */
+        pos += (dst_mode == 3 ? 8 : 2);
+    }
+
+    /* Source Field */
+    if (src_mode) {
+        /* In Legacy: Source PAN is omitted ONLY IF:
+         * Both addresses are present AND PanComp is set to 1.
+         */
+        if (!dst_mode || !pan_comp) {
+            pos += 2; /* Source PAN ID present */
+        }
+        pos += (src_mode == 3 ? 8 : 2);
+    }
+
+    return pos;
+}
+
+/**
+ * lmac154_get_mhr_len_2015 - MHR length for 802.15.4-2015 (Strict Table 7-2)
+ * @pkt: Pointer to frame start
+ */
+static inline uint32_t lmac154_get_mhr_len_2015(const uint8_t *pkt)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+
+    /* Sequence Number Suppression: Bit 8 */
+    uint32_t pos = (fcf & (1 << 8)) ? 2 : 3;
+
+    bool has_dst_pan = false;
+    bool has_src_pan = false;
+
+    /* Strict Mapping of Table 7-2 */
+    if (dst_mode == 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 1); /* Row 1 & 2 */
+    } else if (dst_mode > 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 0); /* Row 3 & 4 */
+    } else if (dst_mode == 0 && src_mode > 0) {
+        has_src_pan = (pan_comp == 0); /* Row 5 & 6 */
+    } else if (dst_mode == 3 && src_mode == 3) {
+        has_dst_pan = (pan_comp == 0); /* Row 7 & 8: Extended-to-Extended */
+    } else {
+        /* Mixed or Short-to-Short: Rows 9-14 */
+        if (pan_comp == 0) {
+            has_dst_pan = true;  /* Row 9, 10, 11 */
+            has_src_pan = true;
+        } else {
+            has_dst_pan = true;  /* Row 12, 13, 14 */
+            has_src_pan = false;
+        }
+    }
+
+    if (has_dst_pan) pos += 2;
+    if (dst_mode > 0) pos += (dst_mode == 3 ? 8 : 2);
+    if (has_src_pan) pos += 2;
+    if (src_mode > 0) pos += (src_mode == 3 ? 8 : 2);
+
+    return pos;
+}
+
+/**
+ * @brief  Calculates the Auxiliary Security Header length.
+ * @param  pkt: Pointer to the start of the frame.
+ * @param  mhr_len: The offset where Aux Header starts (output of lmac154_get_mhr_len).
+ * @return Length of the Security Header (5, 6, 10, or 14 bytes).
+ */
+static inline uint32_t lmac154_get_aux_sec_len(uint8_t *pkt, uint32_t mhr_len)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint8_t sec_ctrl;
+    uint32_t key_id_mode;
+    uint32_t extra;
+
+    /* If Security Enabled bit (Bit 3) is not set, length is 0 */
+    if (!(fcf & 0x0008)) {
+        return 0;
+    }
+
+    /* Read Security Control byte at the calculated offset */
+    sec_ctrl = pkt[mhr_len];
+    key_id_mode = (sec_ctrl >> 3) & 0x03;
+
+    /* Fast lookup using a packed 32-bit constant (Register-based LUT):
+     * modes 0->0, 1->1, 2->5, 3->9 bytes extra for KeyID.
+     */
+    extra = (0x09050100 >> (key_id_mode << 3)) & 0xFF;
+
+    /* Base Security Header is 5 bytes: Security Control(1) + Frame Counter(4) */
+    return 5 + extra;
+}
+
+/**
+ * lmac154_parse_aux_hdr - Safely map and return the next position
+ * @pkt: Pointer to frame start (32-bit aligned)
+ * @mhr_len: Offset to security header
+ * @p_aux_hdr: Output pointer
+ *
+ * Return: Next position pointer.
+ */
+static inline uint32_t lmac154_parse_aux_hdr(uint8_t *pkt, uint32_t mhr_len,
+                        lmac154_aux_hdr_t **p_aux_hdr)
+{
+    uint32_t len;
+    uint8_t *pos = pkt + mhr_len;
+
+    len = lmac154_get_aux_sec_len(pkt, mhr_len);
+    if (len == 0) {
+        if (p_aux_hdr)
+            *p_aux_hdr = NULL;
+        return 0;
+    }
+
+    if (p_aux_hdr)
+        *p_aux_hdr = (lmac154_aux_hdr_t *)pos;
+
+    return len;
+}
+
+/**
+ * lmac154_traverse_ie - IE section traversal
+ * @ie_start: Pointer to the start of IE section
+ * @ie_len: Maximum length to search (buffer limit)
+ * @target_id: Target IE ID to locate; @found_ie is set on first match
+ * @found_ie: Output pointer to the matched IE header (NULL if not found)
+ *
+ * Return: Total bytes from ie_start to the end of the Termination IE.
+ * Always traverses the full IE section regardless of target match.
+ * Returns 0 if a structural error (truncation) is detected.
+ */
+static inline uint32_t lmac154_traverse_ie(uint8_t *ie_start, uint32_t ie_len,
+                       uint8_t target_id, lmac154_ie_hdr_t **found_ie)
+{
+    uint8_t *cur = ie_start;
+    uint8_t *limit = ie_start + ie_len;
+
+    if (found_ie)
+        *found_ie = NULL;
+
+    /* Pre-check: Minimal Header IE is 2 bytes */
+    while (cur + 2 <= limit) {
+        /* RISC-V Safe: Byte-by-byte 16-bit header fetch
+         * Bits: [0:6] Length, [7:14] ID, [15] Type
+         */
+        uint32_t hdr = (uint32_t)(cur[0] | (cur[1] << 8));
+        uint32_t len = hdr & 0x7F;
+        uint32_t id  = (hdr >> 7) & 0xFF;
+        uint32_t total_sz = len + 2;
+
+        /* 1. Fast Termination Check: 0x7E/0x7F both match (id & 0xFE) == 0x7E */
+        if ((id & 0xFE) == 0x7E) {
+            cur += 2;
+            break;
+        }
+
+        /* 2. Boundary Validation */
+        if (cur + total_sz > limit)
+            return 0;
+
+        /* 3. Target Matching - record first occurrence, continue traversal */
+        if (id == target_id) {
+            if (found_ie && !*found_ie)
+                *found_ie = (lmac154_ie_hdr_t *)cur;
+        }
+
+        /* 4. Advance pointer */
+        cur += total_sz;
+    }
+
+    /* Return total length of all traversed IEs (including termination) */
+    return (uint32_t)(cur - ie_start);
+}
+
+/**
+ * @brief  Generate CSL IE and return the computed phase value.
+ * @note   CslPhase = ceil((sample_time - tx_sfd_sym) % period / 10),
+ *         in 10-symbol units per IEEE 802.15.4-2015.
+ * @param  csl_period     CSL period in 10-symbol units.
+ * @param  csl_sample_time  CSL sample time in symbol count.
+ * @param  csl_ie         Output CSL IE buffer.
+ * @param  tx_sfd_sym     Estimated TX SFD time in symbol count.
+ * @return CSL phase value written to the IE.
+ */
+static inline uint16_t lmac154_gen_csl_ie(uint16_t csl_period, uint32_t csl_sample_time,
+                                           lmac154_ie_csl_t *csl_ie, uint32_t tx_sfd_sym)
+{
+    uint32_t period_sym = (uint32_t)csl_period * 10;
+    uint32_t delta_sym  = (csl_sample_time - tx_sfd_sym) % period_sym;
+    uint16_t csl_phase  = (uint16_t)((delta_sym + 9) / 10);
+
+    csl_ie->bf.hdr.length     = 4;
+    csl_ie->bf.hdr.element_id = LMAC154_IE_CSL_ID;
+    csl_ie->bf.hdr.type       = 0;
+    csl_ie->bf.phase          = csl_phase;
+    csl_ie->bf.period         = csl_period;
+
+    return csl_phase;
+}
+
+#endif /* __LMAC154_FRAME_H__ */

--- a/include/bouffalolab/bl61x/lmac154/lmac154_lp.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154_lp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_PDS_H__
+#define __LMAC154_PDS_H__
+
+/****************************************************************************//**
+ * @brief  Store registers to backup memory
+ *
+ * @param  retentionMem: retention memory to hold registers configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepStoreRegs(uint32_t *retentionMem);
+
+/****************************************************************************//**
+ * @brief  Restore registers from backup memory
+ *
+ * @param  retentionMem: retention memory hold register configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepRestoreRegs(uint32_t *retentionMem);
+
+#endif

--- a/include/bouffalolab/bl61x/lmac154/lmac154_lp.h
+++ b/include/bouffalolab/bl61x/lmac154/lmac154_lp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_PDS_H__
+#define __LMAC154_PDS_H__
+
+/****************************************************************************
+ * @brief  Store registers to backup memory
+ *
+ * @param  retentionMem: retention memory to hold registers configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepStoreRegs(uint32_t *retentionMem);
+
+/****************************************************************************
+ * @brief  Restore registers from backup memory
+ *
+ * @param  retentionMem: retention memory hold register configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepRestoreRegs(uint32_t *retentionMem);
+
+#endif

--- a/include/bouffalolab/bl70x/lmac154/lmac154.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154.h
@@ -1,0 +1,1622 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_H__
+#define __LMAC154_H__
+
+#define VERSION_LMAC154_MAJOR 1
+#define VERSION_LMAC154_MINOR 6
+#define VERSION_LMAC154_PATCH 18
+
+typedef void (*lmac154_isr_t)(void);
+
+typedef enum {
+    LMAC154_CHANNEL_NONE = -1,
+    LMAC154_CHANNEL_11 = 0,
+    LMAC154_CHANNEL_12,
+    LMAC154_CHANNEL_13,
+    LMAC154_CHANNEL_14,
+    LMAC154_CHANNEL_15,
+    LMAC154_CHANNEL_16,
+    LMAC154_CHANNEL_17,
+    LMAC154_CHANNEL_18,
+    LMAC154_CHANNEL_19,
+    LMAC154_CHANNEL_20,
+    LMAC154_CHANNEL_21,
+    LMAC154_CHANNEL_22,
+    LMAC154_CHANNEL_23,
+    LMAC154_CHANNEL_24,
+    LMAC154_CHANNEL_25,
+    LMAC154_CHANNEL_26,
+}lmac154_channel_t;
+
+typedef enum {
+    LMAC154_TX_POWER_0dBm  = 0,
+    LMAC154_TX_POWER_1dBm  = 1,
+    LMAC154_TX_POWER_2dBm  = 2,
+    LMAC154_TX_POWER_3dBm  = 3,
+    LMAC154_TX_POWER_4dBm  = 4,
+    LMAC154_TX_POWER_5dBm  = 5,
+    LMAC154_TX_POWER_6dBm  = 6,
+    LMAC154_TX_POWER_7dBm  = 7,
+    LMAC154_TX_POWER_8dBm  = 8,
+    LMAC154_TX_POWER_9dBm  = 9,
+    LMAC154_TX_POWER_10dBm = 10,
+    LMAC154_TX_POWER_11dBm = 11,
+    LMAC154_TX_POWER_12dBm = 12,
+    LMAC154_TX_POWER_13dBm = 13,
+    LMAC154_TX_POWER_14dBm = 14,
+}lmac154_tx_power_t;
+
+typedef enum {
+    LMAC154_DATA_RATE_250K = 0,
+    LMAC154_DATA_RATE_500K = 1,
+    LMAC154_DATA_RATE_1M   = 2,
+    LMAC154_DATA_RATE_2M   = 3,
+}lmac154_data_rate_t;
+
+typedef enum {
+    LMAC154_CCA_MODE_ED        = 0,
+    LMAC154_CCA_MODE_CS        = 1,
+    LMAC154_CCA_MODE_ED_AND_CS = 2,
+    LMAC154_CCA_MODE_ED_OR_CS  = 3,
+}lmac154_cca_mode_t;
+
+typedef enum {
+    LMAC154_FRAME_TYPE_BEACON = 0x01,
+    LMAC154_FRAME_TYPE_DATA   = 0x02,
+    LMAC154_FRAME_TYPE_ACK    = 0x04,
+    LMAC154_FRAME_TYPE_CMD    = 0x08,
+    LMAC154_FRAME_TYPE_MPP    = 0x10,
+}lmac154_frame_type_t;
+
+typedef enum {
+    LMAC154_RF_PWR_OFF        = 0,
+    LMAC154_RF_STATE_RX       = 1,
+    LMAC154_RF_STATE_RX_DOING = 2,
+    LMAC154_RF_STATE_TX       = 3,
+    LMAC154_RF_STATE_IDLE     = 4,
+}lmac154_rf_state_t;
+
+typedef enum {
+    LMAC154_AES_MODE_ENCRYPT = 0,
+    LMAC154_AES_MODE_DECRYPT = 1,
+}lmac154_aes_mode_t;
+
+typedef enum {
+    LMAC154_AES_MIC_LEN_4  = 0,
+    LMAC154_AES_MIC_LEN_8  = 1,
+    LMAC154_AES_MIC_LEN_16 = 2,
+    LMAC154_AES_MIC_LEN_12 = 3,
+}lmac154_aes_mic_len_t;
+
+typedef enum {
+    LMAC154_AES_STATUS_SUCCESS         = 0,
+    LMAC154_AES_STATUS_INVALID_MODE    = -1,
+    LMAC154_AES_STATUS_INVALID_MIC_LEN = -2,
+    LMAC154_AES_STATUS_REENTER         = -3,
+    LMAC154_AES_STATUS_TIMEOUT         = -4,
+}lmac154_aes_status_t;
+
+typedef enum {
+    LMAC154_FPT_STATUS_SUCCESS          = 0,
+    LMAC154_FPT_STATUS_NO_RESOURCE      = -1,
+    LMAC154_FPT_STATUS_ADDR_NOT_FOUND   = -2,
+    LMAC154_FPT_STATUS_EMPTY            = -3,
+    LMAC154_FPT_STATUS_INVALID_PARAM    = -4,
+    LMAC154_FPT_STATUS_INVALID_OPT      = -5
+}lmac154_fpt_status_t;
+
+
+typedef enum {
+    LMAC154_TX_STATUS_TX_FINISHED = 0,
+    LMAC154_TX_STATUS_CSMA_FAILED = 1,
+    LMAC154_TX_STATUS_TX_ABORTED  = 2,
+    LMAC154_TX_STATUS_HW_ERROR    = 3,
+    LMAC154_TX_STATUS_DELAY_ERROR = 4,
+}lmac154_tx_status_t;
+
+typedef enum {
+    LMAC154_EVENT_TIME_RX_START = 0,
+    LMAC154_EVENT_TIME_RX_END   = 1,
+    LMAC154_EVENT_TIME_TX_END   = 4,
+}lmac154_eventTimeType_t;
+
+typedef enum {
+    LMAC154_RX_REJECT_CRC_ERR            = 0x00000001, // will reject packets that CRC check error
+    LMAC154_RX_REJECT_FRAME_TYPE_RVSD    = 0x00000002, // will reject packets that the value of frame type filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_FRAME_VER_RVSD     = 0x00000004, // will reject packets that the value of frame version filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_DST_ADDR_M_RVSD    = 0x00000008, // will reject packets that the value of dest address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_SRC_ADDR_M_RVSD    = 0x00000010, // will reject packets that the value of src address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_DST_PANID_MISMATCH = 0x00000020, // will reject packets that the value of dest PANID does not match with local device
+    LMAC154_RX_REJECT_DST_ADDR_MISMATCH  = 0x00000040, // will reject packets that the value of dest address does not match with local device
+    LMAC154_RX_REJECT_SRC_PANID_MISMATCH = 0x00000080, // will reject packets that the value of src PANID does not match with local device
+
+    LMAC154_RX_REJECT_NONE               = 0x00000000, // will not reject all packets above
+    LMAC154_RX_REJECT_ALL                = 0x000000ff, // will reject all packets above
+}lmac154_rx_reject_policy_t;
+
+typedef enum {
+    LMAC154_RX_ACCEPT_CRC_ERR            = 0x00000001, // able to receive packets that CRC check error
+    LMAC154_RX_ACCEPT_FRAME_TYPE_RVSD    = 0x00000002, // able to receive packets that the value of frame type filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_FRAME_VER_RVSD     = 0x00000004, // able to receive packets that the value of frame version filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_DST_ADDR_M_RVSD    = 0x00000008, // able to receive packets that the value of dest address mode filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_SRC_ADDR_M_RVSD    = 0x00000010, // able to receive packets that the value of src address mode filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_DST_PANID_MISMATCH = 0x00000020, // able to receive packets that the value of dest PANID does not match with local device
+    LMAC154_RX_ACCEPT_DST_ADDR_MISMATCH  = 0x00000040, // able to receive packets that the value of dest address does not match with local device
+    LMAC154_RX_ACCEPT_SRC_PANID_MISMATCH = 0x00000080, // able to receive packets that the value of src PANID does not match with local device
+
+    LMAC154_RX_ACCEPT_NONE               = 0x00000000, // not able to receive all packets above
+    LMAC154_RX_ACCEPT_ALL                = 0x000000ff, // able to receive all packets above 
+}lmac154_rx_accept_policy_t;
+
+typedef enum {
+    lmac154_addr_info_none               = 0x00000000,
+    lmac154_addr_info_panid              = 0x00000001,
+    lmac154_addr_info_short_addr         = 0x00000002,
+    lmac154_addr_info_ext_addr           = 0x00000004,
+    lmac154_addr_info_panid_short_addr   = lmac154_addr_info_panid | lmac154_addr_info_short_addr,
+    lmac154_addr_info_panid_ext_addr     = lmac154_addr_info_panid | lmac154_addr_info_ext_addr,
+} lmac154_addr_info_t;
+
+
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK       (7)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA       (1)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK        (2)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD        (3)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP        (5)
+
+#define LMAC154_FRAME_SECURITY_MASK                 (1 << 3)
+#define LMAC154_FRAME_FRAME_PENDING_MASK            (1 << 4)
+#define LMAC154_FRAME_ACK_REQUEST_MASK              (1 << 5)
+#define LMAC154_FRAME_PANID_COMPRESSION             (1 << 6)
+#define LMAC154_FRAME_SEQ_SUPRESSION_MASK           (1 << 8)
+#define LMAC154_FRAME_IE_MASK                       (1 << 9)
+#define LMAC154_FRAME_ADDR_DEST_NONE                (0 << 10)
+#define LMAC154_FRAME_ADDR_DEST_SHORT               (2 << 10)
+#define LMAC154_FRAME_ADDR_DEST_EXT                 (3 << 10)
+#define LMAC154_FRAME_ADDR_DEST_MASK                (3 << 10)
+#define LMAC154_FRAME_VERSION_MASK                  (3 << 12)
+#define LMAC154_FRAME_VERSION_2015                  (2 << 12)
+#define LMAC154_FRAME_ADDR_SRC_NONE                 (0 << 14)
+#define LMAC154_FRAME_ADDR_SRC_SHORT                (2 << 14)
+#define LMAC154_FRAME_ADDR_SRC_EXT                  (3 << 14)
+#define LMAC154_FRAME_ADDR_SRC_MASK                 (3 << 14)
+
+#define LMAC154_FRAME_MPP_LONG_FRAME_BIT            (1 << 3)
+#define LMAC154_FRAME_MPP_SECURITY_BIT              (1 << 9)
+#define LMAC154_FRAME_MPP_ACK_REQ                   (1 << 14)
+
+#define LMAC154_FRAME_CMD_DATA_REQUEST              (4)
+#define LMAC154_FRAME_IS_CMD(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD)
+#define LMAC154_FRAME_IS_DATA(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA)
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+
+#define LMAC154_FRAME_IS_ACK_REQ(x)                 (((x) & LMAC154_FRAME_ACK_REQUEST_MASK) == LMAC154_FRAME_ACK_REQUEST_MASK)
+#define LMAC154_FRAME_IS_PANID_COMPRESSED(x)        (((x) & LMAC154_FRAME_PANID_COMPRESSION) == LMAC154_FRAME_PANID_COMPRESSION)
+
+
+#define LMAC154_FRAME_IS_FRAME_2015(x)              (((x) & LMAC154_FRAME_VERSION_MASK) == LMAC154_FRAME_VERSION_2015)
+
+#define LMAC154_FRAME_IS_FRAME_PENDED(x)            ((x) & LMAC154_FRAME_FRAME_PENDING_MASK)
+#define LMAC154_FRAME_IS_NORMAL_SECURITY(x)         ((x & LMAC154_FRAME_SECURITY_MASK) == LMAC154_FRAME_SECURITY_MASK)
+
+#define LMAC154_FRAME_IS_MPP(x)                     ((x & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP)
+#define LMAC154_FRAME_IS_MPP_LONG_FRAME(x)          ((x & LMAC154_FRAME_MPP_LONG_FRAME_BIT) == LMAC154_FRAME_MPP_LONG_FRAME_BIT)
+#define LMAC154_FRAME_IS_MPP_SECURITY(x)            (LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_SECURITY_BIT) == LMAC154_FRAME_MPP_SECURITY_BIT)
+
+#define LMAC154_FRAME_IS_MPP_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP(x) && LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_ACK_REQ) == LMAC154_FRAME_MPP_ACK_REQ)
+#define LMAC154_FRAME_IS_ENH_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP_ACK_REQ(x) || (LMAC154_FRAME_IS_ACK_REQ(x) && LMAC154_FRAME_IS_FRAME_2015(x)))
+#define LMAC154_FRAME_IS_IMM_ACK_REQ(x)             (LMAC154_FRAME_IS_ACK_REQ(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+
+#define LMAC154_FRAME_IS_SECURITY_ENABLED(x)        (LMAC154_FRAME_IS_MPP(x) ?                                                          \
+                                                        (LMAC154_FRAME_IS_MPP_SECURITY(x) : LMAC154_FRAME_IS_NORMAL_SECURITY(x))
+
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+#define LMAC154_FRAME_IS_IMM_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_ENH_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_IE_EXIST(x)                (((x) & LMAC154_FRAME_IE_MASK) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+#define LMAC154_FRAME_GET_SRC_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_SRC_MASK)
+#define LMAC154_FRAME_GET_DST_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_DEST_MASK)
+
+
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_MASK          (3 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_0             (0 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_1             (1 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_2             (2 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_3             (3 << 3)
+
+#define LMAC154_LIFS                    40
+#define LMAC154_SIFS                    12
+#define LMAC154_AIFS                    LMAC154_SIFS
+#define LMAC154_SIFS_MAX_FRAME_SIZE     18
+#define LMAC154_TURNAROUND              12
+#define LMAC154_PKT_MAX_LEN             127
+#define LMAC154_PREAMBLE_LEN            8
+
+#define LMAC154_US_PER_SYMBOL_BITS      4
+#define LMAC154_US_PER_SYMBOL           (1 << LMAC154_US_PER_SYMBOL_BITS)
+#define LMAC154_US_PER_SYMBOL_MASK      (LMAC154_US_PER_SYMBOL - 1)
+
+/****************************************************************************//**
+ * @brief  Initialize the hardware module
+ *         Call this function first
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_init(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC 15.4 feature for 2015 version
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2015Feature(void);
+
+/****************************************************************************//**
+ * @brief  Disable MAC 15.4 feature for 2015 version
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2015Feature(void);
+
+/****************************************************************************//**
+ * @brief  Enable second stack for dual stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2ndStack(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable second stack for dual stack, which is disable by default
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2ndStack(void);
+
+
+/****************************************************************************//**
+ * @brief  Check whether the second stack is enabled
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+uint32_t lmac154_is2ndStackEnabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Get whether lmac154 is disabled
+ *
+ * @param  None
+ *
+ * @return 1 for disabled, 0 for enabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isDisabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Monitor the hardware state
+ *         Call this function periodically (1ms recommended) if needed
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_monitor(void);
+
+
+/****************************************************************************//**
+ * @brief  Get the lmac154 interrupt handler for interrupt registration of M154_IRQn
+ *
+ * @param  None
+ *
+ * @return The lmac154 interrupt handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptHandler(void);
+lmac154_isr_t lmac154_get2015InterruptHandler(void);
+
+/****************************************************************************//**
+ * @brief  Get the version number
+ *
+ * @param  None
+ *
+ * @return The library version number
+ *
+*******************************************************************************/
+uint32_t lmac154_getVersionNumber(void);
+
+/****************************************************************************//**
+ * @brief  Get the version number string
+ *
+ * @param  None
+ *
+ * @return The library version number string
+ *
+*******************************************************************************/
+char * lmac154_getVersionString(void);
+
+/****************************************************************************//**
+ * @brief  Enable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer accepts all frames received from the PHY layer
+ *         Able to receive frames without any IFS but rx sensitivity may be degraded if enhanced_mode = 1
+ *         The MPDU is unavailable in lmac154_rxDoneEvent if ignore_mpdu = 1
+ *
+ * @param  enhanced_mode: 0: standard mode, 1: enhanced mode
+ * @param  ignore_mpdu: 0: read mpdu from registers, 1: do not read mpdu from registers
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxPromiscuousMode(uint8_t enhanced_mode, uint8_t ignore_mpdu);
+
+
+/****************************************************************************//**
+ * @brief  Disable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer only accepts frames that pass the address filtering
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxPromiscuousMode(void);
+
+
+/****************************************************************************//**
+ * @brief  Get whether rx promiscuous mode is enabled
+ *
+ * @param  None
+ *
+ * @return 1 for enabled; 0 for disabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isRxPromiscuousModeEnabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRx(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRx(void);
+
+
+/****************************************************************************//**
+ * @brief  Set rx on/off state when idle state
+ *
+ * @param  isRxOnWhenIdle: true is rx on when idle; otherwhile is rx off when idle
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxStateWhenIdle(bool isRxOnWhenIdle);
+
+/****************************************************************************//**
+ * @brief  Get rx on/off state when idle state
+ *
+ * @param  None 
+ *
+ * @return true is rx on when idle; otherwhile is rx off when idle
+ *
+*******************************************************************************/
+bool lmac154_isRxStateWhenIdle(void);
+
+/****************************************************************************//**
+ * @brief  Set the number of maximum retransmission times (default 0)
+ *         Will perform retransmission in case ack is not received if num > 0
+ *         Will raise lmac154_ackEvent(ack_received = 0) after maximum retransmission times
+ *
+ * @param  num: number of maximum retransmission times
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRetry(uint32_t num);
+
+
+/****************************************************************************//**
+ * @brief  Trigger TX
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma: 0: without CSMA, 1: with CSMA
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_triggerTx(uint8_t *DataPtr, uint8_t length, uint8_t csma);
+
+
+/****************************************************************************//**
+ * @brief  Trigger TX with tx time specified
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma_cca: 0: without CSMA, 1: with CSMA/CCA
+ * @param  baseTimeUs: the base time us for delay tx trigger
+ * @param  delayUs: the delay time from baseTimeUs to tx trigger
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerTxDelay(uint8_t *DataPtr, uint32_t length, uint32_t csma_cca, 
+    uint64_t baseTimeUs, uint32_t delayUs);
+
+/****************************************************************************//**
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerTx or 
+ *         lmac154_triggerTxDelay without data specified.
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+uint32_t lmac154_postFillMPDU(uint8_t *DataPtr, uint32_t length);
+
+/****************************************************************************//**
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerTx or 
+ *         lmac154_triggerTxDelay without data specified.
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 1 is selected
+ *
+*******************************************************************************/
+uint32_t lmac154_isTriggerTimeSelected(void);
+
+/****************************************************************************//**
+ * @brief  Run tx continuous modulation (PRBS15 pattern)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCM(void);
+
+#if defined(BL702) || defined(BL702L)
+/****************************************************************************//**
+ * @brief  Run tx continuous wave (single tone)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCW(void);
+#endif
+
+
+/****************************************************************************//**
+ * @brief  Reset tx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetTx(void);
+
+/****************************************************************************//**
+ * @brief  Reset rx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetRx(void);
+
+/****************************************************************************//**
+ * @brief  Set the channel (default LMAC154_CHANNEL_11)
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setChannel(lmac154_channel_t ch_ind);
+
+
+/****************************************************************************//**
+ * @brief  Get the channel
+ *
+ * @param  None
+ *
+ * @return The channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+*******************************************************************************/
+lmac154_channel_t lmac154_getChannel(void);
+
+
+/****************************************************************************//**
+ * @brief  Get RSSI in dBm
+ *
+ * @param  None
+ *
+ * @return RSSI in dBm
+ *
+*******************************************************************************/
+int lmac154_getRSSI(void);
+
+
+/****************************************************************************//**
+ * @brief  Get LQI
+ *
+ * @param  None
+ *
+ * @return LQI
+ *
+*******************************************************************************/
+int lmac154_getLQI(void);
+
+
+/****************************************************************************//**
+ * @brief  Get SFD correlation
+ *
+ * @param  None
+ *
+ * @return SFD correlation
+ *
+*******************************************************************************/
+uint8_t lmac154_getSFDCorrelation(void);
+
+
+/****************************************************************************//**
+ * @brief  Get the frequency offset in Hz
+ *
+ * @param  None
+ *
+ * @return The frequency offset in Hz
+ *
+*******************************************************************************/
+int lmac154_getFrequencyOffset(void);
+
+/****************************************************************************//**
+ * @brief  Set country code for tx power adjustment
+ *
+ * @param  country_code: country code, for example: CN
+ *
+ * @return true, if country code is valid.
+ *
+*******************************************************************************/
+bool lmac154_setCountryCode(const char * country_code);
+
+/****************************************************************************//**
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPower(lmac154_tx_power_t power_dbm);
+
+/****************************************************************************//**
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @param country_code: country code, for example: CN
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPowerWithPowerLimit(lmac154_tx_power_t power_dbm, lmac154_channel_t ch_ind, const char *country_code);
+
+/****************************************************************************//**
+ * @brief  Get tx power
+ *
+ * @param  None
+ *
+ * @return tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+*******************************************************************************/
+lmac154_tx_power_t lmac154_getTxPower(void);
+
+
+/****************************************************************************//**
+ * @brief  Set tx data rate (default LMAC154_DATA_RATE_250K)
+ *         The maximum tx mpdu length is 127 bytes for 250kbps tx data rate, and 255 bytes for others
+ *
+ * @param  rate: LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxDataRate(lmac154_data_rate_t rate);
+
+
+/****************************************************************************//**
+ * @brief  Enable auto rx data rate (default disabled)
+ *         The maximum rx mpdu length is 127 bytes for 250kbps rx data rate, and 255 bytes for others
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAutoRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable auto rx data rate (default disabled)
+ *         The rx data rate is 250kbps, and the maximum rx mpdu length is 127 bytes
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAutoRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Get rx data rate
+ *
+ * @param  None
+ *
+ * @return LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+*******************************************************************************/
+lmac154_data_rate_t lmac154_getRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Set CCA mode (default LMAC154_CCA_MODE_ED_AND_CS)
+ *
+ * @param  mode: LMAC154_CCA_MODE_ED, LMAC154_CCA_MODE_CS, LMAC154_CCA_MODE_ED_AND_CS, or LMAC154_CCA_MODE_ED_OR_CS
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCCAMode(lmac154_cca_mode_t mode);
+
+
+/****************************************************************************//**
+ * @brief  Set CCA ED threshold (default -71dBm)
+ *
+ * @param  threshold: ED threshold ranging from -122 to 5 in dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEDThreshold(int threshold);
+
+
+/****************************************************************************//**
+ * @brief  Get CCA ED threshold
+ *
+ * @param  None
+ *
+ * @return ED threshold
+ *
+*******************************************************************************/
+int lmac154_getEDThreshold(void);
+
+
+/****************************************************************************//**
+ * @brief  Run CCA
+ *
+ * @param  rssi: rssi output ranging from -122 to 5 in dBm
+ *
+ * @return CCA result: 0: channel idle, 1: channel busy
+ *
+*******************************************************************************/
+uint8_t lmac154_runCCA(int *rssi);
+
+
+/****************************************************************************//**
+ * @brief  Set PAN ID (default 0x4321)
+ *
+ * @param  pid: PAN ID
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setPanId(uint16_t pid);
+void lmac154_set2ndPanId(uint16_t pid);
+
+
+/****************************************************************************//**
+ * @brief  Get PAN ID
+ *
+ * @param  None
+ *
+ * @return PAN ID
+ *
+*******************************************************************************/
+uint16_t lmac154_getPanId(void);
+uint16_t lmac154_get2ndPanId(void);
+
+
+/****************************************************************************//**
+ * @brief  Set 16-bit short address (default 0x0000)
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setShortAddr(uint16_t sadr);
+void lmac154_set2ndShortAddr(uint16_t sadr);
+
+
+/****************************************************************************//**
+ * @brief  Get 16-bit short address
+ *
+ * @param  None 
+ *
+ * @return 16-bit short address
+ *
+*******************************************************************************/
+uint16_t lmac154_getShortAddr(void);
+uint16_t lmac154_get2ndShortAddr(void);
+
+
+/****************************************************************************//**
+ * @brief  Set 64-bit long address (default 0xACDE4800_00000002)
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setLongAddr(uint8_t *ladr);
+void lmac154_set2ndLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Get 64-bit long address
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getLongAddr(uint8_t *ladr);
+void lmac154_get2ndLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Enable frame type filtering (default disabled)
+ *         Will only receive specified frame types
+ *
+ * @param  frame_types: any combination of LMAC154_FRAME_TYPE_XXX (BEACON, DATA, ACK, or CMD), via bitwise OR ('|') operation
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableFrameTypeFiltering(uint8_t frame_types);
+
+
+/****************************************************************************//**
+ * @brief  Disable frame type filtering (default disabled)
+ *         Will receive all valid frame types (BEACON, DATA, ACK, or CMD)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableFrameTypeFiltering(void);
+
+
+/****************************************************************************//**
+ * @brief  Set rx reject policy
+ *
+ * @param policy : enum lmac154_rx_reject_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxRejectPolicy(lmac154_rx_reject_policy_t policy);
+
+
+/****************************************************************************//**
+ * @brief  Get rx reject policy
+ *
+ * @param None
+ *
+ * @return Rx reject policy
+ *
+*******************************************************************************/
+lmac154_rx_reject_policy_t lmac154_getRxRejectPolicy(void);
+
+
+/****************************************************************************//**
+ * @brief  set rx accept policy
+ *         
+ *
+ * @param policy : enum lmac154_rx_accept_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxAcceptPolicy(lmac154_rx_accept_policy_t policy);
+
+
+/****************************************************************************//**
+ * @brief  get rx accept policy
+ *         
+ *
+ * @param None
+ *
+ * @return lmac154_rx_accept_policy : enum lmac154_rx_accept_policy_t
+ *
+*******************************************************************************/
+lmac154_rx_accept_policy_t lmac154_getRxAcceptPolicy(void);
+
+
+/****************************************************************************//**
+ * @brief  Set external PA
+ *         Restriction: txpin % 5 != rxpin % 5
+ *
+ * @param  txpin: tx pin ranging from 0 to 31
+ * @param  rxpin: rx pin ranging from 0 to 31
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setExtPA(uint8_t txpin, uint8_t rxpin);
+
+
+/****************************************************************************//**
+ * @brief  Get RF state
+ *
+ * @param  None
+ *
+ * @return LMAC154_RF_STATE_RX, LMAC154_RF_STATE_RX_DOING, LMAC154_RF_STATE_TX, or LMAC154_RF_STATE_IDLE
+ *
+*******************************************************************************/
+lmac154_rf_state_t lmac154_getRFState(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable the coexistence of 802.15.4 and BLE wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableCoex(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableCoex(void);
+
+
+/****************************************************************************//**
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCoexPriority(bool is_rx_on_after_rx_abort_enable, uint32_t tx_priority, 
+    uint32_t rx_unicast_priority, uint32_t rx_sfd_priority, uint32_t rx_idle_priority);
+
+/****************************************************************************//**
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getCoexPriority(bool * is_rx_on_after_rx_abort_enable, uint32_t * tx_priority, 
+    uint32_t * rx_unicast_priority, uint32_t * rx_sfd_priority, uint32_t * rx_idle_priority);
+
+/****************************************************************************//**
+ * @brief  Enable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableTxAbortInt(void);
+
+/****************************************************************************//**
+ * @brief  Disable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableTxAbortInt(void);
+
+/****************************************************************************//**
+ * @brief  Enable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableHwAutoTxAck(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableHwAutoTxAck(void);
+
+/****************************************************************************//**
+ * @brief  Get whether hardware auto transmission of ack frame is enabled
+ *
+ * @param  None
+ *
+ * @return ture, enabled
+ *
+*******************************************************************************/
+bool lmac154_isHwAutoTxAckEnabled(void);
+
+/****************************************************************************//**
+ * @brief  Enable lmac154_ackEvent (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable lmac154_ackEvent (default enabled)
+ *         Will raise lmac154_rxDoneEvent instead when ack is received
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxSecMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxSecMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableReqEnhAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableReqEnhAckEvent(void);
+
+/****************************************************************************//**
+ * @brief  Get the receiving or received mpdu length in bytes (crc included)
+ *
+ * @param  None
+ *
+ * @return The receiving or received mpdu length
+ *
+*******************************************************************************/
+uint8_t lmac154_getRxLength(void);
+
+
+/****************************************************************************//**
+ * @brief  Read rx data (crc not included)
+ *
+ * @param  buf: pointer to data buffer
+ * @param  offset: data offset ranging from 0 to 252 in bytes
+ * @param  len: data length ranging from 1 to 253-offset in bytes
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxData(uint8_t *buf, uint8_t offset, uint8_t len);
+
+
+/****************************************************************************//**
+ * @brief  Read rx crc
+ *
+ * @param  crc: byte array to carry rx crc
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxCrc(uint8_t crc[2]);
+
+
+/****************************************************************************//**
+ * @brief  Set the maximum wait time for ack frame (default 864us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setAckWaitTime(uint16_t time_us);
+
+/****************************************************************************//**
+ * @brief  Get the maximum wait time for imm-ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getAckWaitTime(void);
+
+/****************************************************************************//**
+ * @brief  Set the maximum wait time for enh-ack ack frame (default 1500us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEnhAckWaitTime(uint16_t time_us);
+
+/****************************************************************************//**
+ * @brief  Get the maximum wait time for enh-ack ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getEnhAckWaitTime(void);
+
+/****************************************************************************//**
+ * @brief  Set the maximum and minimum CSMA-CA backoff exponent
+ *
+ * @param  max_be: maximum BE ranging from 3 to 8, default 5
+ * @param  min_be: minimum BE ranging from 0 to max_be, default 3
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setBE(uint8_t max_be, uint8_t min_be);
+
+/****************************************************************************//**
+ * @brief  Set maximum CSMA backoff
+ *
+ * @param  maxBackoff: maximum CSMA backoff
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setMaxCsmaBackoff(uint8_t maxBackoff);
+
+/****************************************************************************//**
+ * @brief  Set tx-rx transition time
+ *
+ * @param  time: us
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRxTransTime(uint8_t timeInUs);
+
+/****************************************************************************//**
+ * @brief  Get event timestamps
+ *
+ * @param  type: event timestamp type
+ *
+ * @return timestamp
+ *
+*******************************************************************************/
+uint64_t lmac154_getEventTimeUs(lmac154_eventTimeType_t type);
+
+bool lmac154_fptSetMaxNum(uint32_t shortAddrNum, uint32_t longAddrNum);
+
+/****************************************************************************//**
+ * @brief  Run AES CCM
+ *
+ * @param  mode: LMAC154_AES_MODE_ENCRYPT or LMAC154_AES_MODE_DECRYPT
+ * @param  a_data: pointer to additional authentication data buffer
+ * @param  a_len: length of additional authentication data in bytes
+ * @param  nonce: pointer to 13-byte nonce buffer
+ * @param  key: pointer to 4-word key buffer
+ * @param  mic_len: LMAC154_MIC_LEN_4, LMAC154_MIC_LEN_8, LMAC154_MIC_LEN_12, or LMAC154_MIC_LEN_16
+ * @param  mic: pointer to mic buffer
+ * @param  input_data: pointer to input data buffer
+ * @param  output_data: pointer to output data buffer
+ * @param  len: length of input data in bytes
+ *
+ * @return The error code
+ *
+*******************************************************************************/
+lmac154_aes_status_t lmac154_runAESCCM(lmac154_aes_mode_t mode, 
+                                       const uint8_t *a_data, 
+                                       uint8_t a_len, 
+                                       const uint8_t *nonce, 
+                                       const uint32_t *key, 
+                                       lmac154_aes_mic_len_t mic_len, 
+                                       uint32_t *mic, 
+                                       const uint32_t *input_data, 
+                                       uint32_t *output_data, 
+                                       uint8_t len);
+
+
+
+
+// hardware frame pending table (256 bytes)
+// shared by short addresses and long addresses (supports up to 128 short addresses or 32 long addresses or mixed)
+// used by hardware to set the frame pending bit of hw auto tx ack
+// if the address is not found in the table (e.g. not set or removed), the frame pending bit of hw auto tx ack is 1
+
+
+/****************************************************************************//**
+ * @brief  Add (or update) the key-value pair {sadr: pending} to (in) the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetShortAddrPending(uint16_t sadr, uint8_t pending);
+
+
+/****************************************************************************//**
+ * @brief  Add (or update) the key-value pair {ladr: pending} to (in) the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetLongAddrPending(uint8_t *ladr, uint8_t pending);
+
+
+/****************************************************************************//**
+ * @brief  Get the corresponding frame pending bit of the short address in the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetShortAddrPending(uint16_t sadr, uint8_t *pending);
+
+
+/****************************************************************************//**
+ * @brief  Get the corresponding frame pending bit of the long address in the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetLongAddrPending(uint8_t *ladr, uint8_t *pending);
+
+
+/****************************************************************************//**
+ * @brief  Remove the key-value pair {sadr: pending} from the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveShortAddr(uint16_t sadr);
+
+
+/****************************************************************************//**
+ * @brief  Remove the key-value pair {ladr: pending} from the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Get short address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetShortAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************//**
+ * @brief  Get long address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetLongAddrList(void *list, uint8_t *entry_num);
+
+
+/****************************************************************************//**
+ * @brief  Set frame pending bit according to frame pending table, or force to set to 1
+ *
+ * @param  force: 0: set according to frame pending table (default), 1: force to set to 1
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptForcePending(uint8_t force);
+
+
+/****************************************************************************//**
+ * @brief  Clear the frame pending table
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptClear(void);
+
+
+/****************************************************************************//**
+ * @brief  Print the frame pending table using specified print function
+ *
+ * @param  print_func: user specified print function
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptDump(int print_func(const char *fmt, ...));
+
+
+// functions below are callback functions running in the interrupt context
+// should be implemented by user if needed
+
+
+/****************************************************************************//**
+ * @brief  Tx Done Event
+ *         Will be raised after calling lmac154_triggerTx
+ *
+ * @param  tx_status: LMAC154_TX_STATUS_XXX (TX_FINISHED, CSMA_FAILED, TX_ABORTED, or HW_ERROR)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_txDoneEvent(lmac154_tx_status_t tx_status);
+
+
+/****************************************************************************//**
+ * @brief  Ack Event
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  frame_pending: frame pending bit in ack frame
+ * @param  seq_num: sequence number in ack frame
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackEvent(uint8_t ack_received, uint8_t frame_pending, uint8_t seq_num);
+
+
+/****************************************************************************//**
+ * @brief  Ack Event with ack frame
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  rx_buf: pointer to the ack frame buffer
+ * @param  len: ACK frame length
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackFrameEvent(uint8_t ack_received, uint8_t *rx_buf, uint8_t len);
+
+
+/****************************************************************************//**
+ * @brief  Rx Done Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received mpdu length in bytes (crc included)
+ * @param  crc_fail: 0: crc pass, 1: crc fail
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxDoneEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t crc_fail);
+
+/****************************************************************************//**
+ * @brief  Rx Start Event
+ *         Will be raised when rx on MAC sublayer starts
+ *         lmac154_getRxLength is available because it is obtained from PHY layer
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Hardware auto tx ack done event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_hwAutoTxAckDoneEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  A 2015 version unicast packet received and enh-ack is required to respond
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_reqEnhAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+
+/****************************************************************************//**
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxSecMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+#if CONFIG_LMAC154_LOG
+void lmac154_log_init(void);
+void lmac154_log(const char *format, ...);
+void lmac154_logs_output(void);
+#endif
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get memory address of destination PAN ID 
+ *         and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to the destination PAN ID in input frame, if present.
+ * @param  a_sa: pointer to destination short address in input frame, if present.
+ * @param  a_xa: pointer to destination extended address in input frame, 
+ *               if present.
+ * @return None
+*******************************************************************************/
+void lmac154_parseDestAddress(uint8_t * a_pkt, uint16_t ** a_panid, 
+                              uint16_t ** a_sa, uint8_t ** a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get memory address of source PANID 
+ *         and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to the source PAN ID in input frame, if present.
+ * @param  a_sa: pointer to source short address in input frame, if present.
+ * @param  a_xa: pointer to source extended address in input frame, if present.
+ * 
+ * @return None
+*******************************************************************************/
+void lmac154_parseSrcAddress(uint8_t * a_pkt, uint16_t **a_panid, 
+                             uint16_t ** a_sa, uint8_t ** a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get destination PAN ID and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to save destination PAN ID from input frame
+ * @param  a_sa: pointer to save destination short address from input frame, 
+ *              if present.
+ * @param  a_xa: pointer to save destination extended address from input frame, 
+ *              if present.
+ * 
+ * @return lmac154_addr_info_t to indicate information of source address
+*******************************************************************************/
+lmac154_addr_info_t lmac154_getDestAddress(uint8_t * a_pkt, uint16_t * a_panid, 
+                                           uint16_t * a_sa, uint8_t * a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get source PAN ID and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to save source PAN ID from input frame
+ * @param  a_sa: pointer to save source short address from input frame, 
+ *              if present.
+ * @param  a_xa: pointer to save source extended address from input frame, 
+ *              if present.
+ * 
+ * @return lmac154_addr_info_t to indicate information of source address
+*******************************************************************************/
+lmac154_addr_info_t lmac154_getSrcAddress(uint8_t * a_pkt, uint16_t * a_panid, 
+                                          uint16_t * a_sa, uint8_t * a_xa);
+
+#endif

--- a/include/bouffalolab/bl70x/lmac154/lmac154.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154.h
@@ -1,0 +1,1685 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_H__
+#define __LMAC154_H__
+
+#define VERSION_LMAC154_MAJOR 1
+#define VERSION_LMAC154_MINOR 7
+#define VERSION_LMAC154_PATCH 7
+
+#ifndef CONFIG_LMAC154_DBG
+#define CONFIG_LMAC154_DBG 0
+#endif
+
+#define M154_RD_WORD(addr)                          (*((volatile uint32_t *)(uintptr_t)(addr)))
+#define M154_WR_WORD(addr, val)                     ((*(volatile uint32_t *)(uintptr_t)(addr)) = (val))
+#define M154_RD_REG(addr, regname)                  M154_RD_WORD(addr + regname##_OFFSET)
+#define M154_WR_REG(addr, regname, val)             M154_WR_WORD(addr + regname##_OFFSET, val)
+
+#define M154_SET_REG_BIT(val, bitname)              ((val) | (1U << bitname##_POS))
+#define M154_CLR_REG_BIT(val, bitname)              ((val)&bitname##_UMSK)
+#define M154_GET_REG_BITS_VAL(val, bitname)         (((val)&bitname##_MSK) >> bitname##_POS)
+#define M154_SET_REG_BITS_VAL(val, bitname, bitval) (((val)&bitname##_UMSK) | ((uint32_t)(bitval) << bitname##_POS))
+#define M154_IS_REG_BIT_SET(val, bitname)           (((val) & (1U << (bitname##_POS))) != 0)
+
+typedef void (*lmac154_isr_t)(void);
+
+typedef enum {
+    LMAC154_CHANNEL_NONE = -1,
+    LMAC154_CHANNEL_11 = 0,
+    LMAC154_CHANNEL_12,
+    LMAC154_CHANNEL_13,
+    LMAC154_CHANNEL_14,
+    LMAC154_CHANNEL_15,
+    LMAC154_CHANNEL_16,
+    LMAC154_CHANNEL_17,
+    LMAC154_CHANNEL_18,
+    LMAC154_CHANNEL_19,
+    LMAC154_CHANNEL_20,
+    LMAC154_CHANNEL_21,
+    LMAC154_CHANNEL_22,
+    LMAC154_CHANNEL_23,
+    LMAC154_CHANNEL_24,
+    LMAC154_CHANNEL_25,
+    LMAC154_CHANNEL_26,
+}lmac154_channel_t;
+
+typedef enum {
+    LMAC154_TX_POWER_0dBm  = 0,
+    LMAC154_TX_POWER_1dBm  = 1,
+    LMAC154_TX_POWER_2dBm  = 2,
+    LMAC154_TX_POWER_3dBm  = 3,
+    LMAC154_TX_POWER_4dBm  = 4,
+    LMAC154_TX_POWER_5dBm  = 5,
+    LMAC154_TX_POWER_6dBm  = 6,
+    LMAC154_TX_POWER_7dBm  = 7,
+    LMAC154_TX_POWER_8dBm  = 8,
+    LMAC154_TX_POWER_9dBm  = 9,
+    LMAC154_TX_POWER_10dBm = 10,
+    LMAC154_TX_POWER_11dBm = 11,
+    LMAC154_TX_POWER_12dBm = 12,
+    LMAC154_TX_POWER_13dBm = 13,
+    LMAC154_TX_POWER_14dBm = 14,
+}lmac154_tx_power_t;
+
+typedef enum {
+    LMAC154_DATA_RATE_250K = 0,
+    LMAC154_DATA_RATE_500K = 1,
+    LMAC154_DATA_RATE_1M   = 2,
+    LMAC154_DATA_RATE_2M   = 3,
+}lmac154_data_rate_t;
+
+typedef enum {
+    LMAC154_CCA_MODE_ED        = 0,
+    LMAC154_CCA_MODE_CS        = 1,
+    LMAC154_CCA_MODE_ED_AND_CS = 2,
+    LMAC154_CCA_MODE_ED_OR_CS  = 3,
+}lmac154_cca_mode_t;
+
+typedef enum {
+    LMAC154_FRAME_TYPE_BEACON = 0x01,
+    LMAC154_FRAME_TYPE_DATA   = 0x02,
+    LMAC154_FRAME_TYPE_ACK    = 0x04,
+    LMAC154_FRAME_TYPE_CMD    = 0x08,
+    LMAC154_FRAME_TYPE_MPP    = 0x10,
+}lmac154_frame_type_t;
+
+typedef enum {
+    LMAC154_RF_STATE_RX_TRIG        = 1,
+    LMAC154_RF_STATE_RX             = 2,
+    LMAC154_RF_STATE_RX_DOING       = 3,
+    LMAC154_RF_STATE_ACK_DOING      = 4,
+    LMAC154_RF_STATE_TX             = 5,
+    LMAC154_RF_STATE_CSMA           = 6,
+    LMAC154_RF_STATE_IDLE           = 7,
+}lmac154_rf_state_t;
+
+typedef enum {
+    LMAC154_AES_MODE_ENCRYPT = 0,
+    LMAC154_AES_MODE_DECRYPT = 1,
+}lmac154_aes_mode_t;
+
+typedef enum {
+    LMAC154_AES_MIC_LEN_4  = 0,
+    LMAC154_AES_MIC_LEN_8  = 1,
+    LMAC154_AES_MIC_LEN_16 = 2,
+    LMAC154_AES_MIC_LEN_12 = 3,
+}lmac154_aes_mic_len_t;
+
+typedef enum {
+    LMAC154_AES_STATUS_SUCCESS         = 0,
+    LMAC154_AES_STATUS_INVALID_MODE    = -1,
+    LMAC154_AES_STATUS_INVALID_MIC_LEN = -2,
+    LMAC154_AES_STATUS_REENTER         = -3,
+    LMAC154_AES_STATUS_TIMEOUT         = -4,
+}lmac154_aes_status_t;
+
+typedef enum {
+    LMAC154_FPT_STATUS_SUCCESS          = 0,
+    LMAC154_FPT_STATUS_NO_RESOURCE      = -1,
+    LMAC154_FPT_STATUS_ADDR_NOT_FOUND   = -2,
+    LMAC154_FPT_STATUS_EMPTY            = -3,
+    LMAC154_FPT_STATUS_INVALID_PARAM    = -4,
+    LMAC154_FPT_STATUS_INVALID_OPT      = -5
+}lmac154_fpt_status_t;
+
+typedef enum {
+    LMAC154_TX_STATUS_TX_FINISHED = 0,
+    LMAC154_TX_STATUS_ACKED       = 1,
+    LMAC154_TX_STATUS_CSMA_FAILED = 2,
+    LMAC154_TX_STATUS_TX_ABORTED  = 3,
+    LMAC154_TX_STATUS_HW_ERROR    = 4,
+    LMAC154_TX_STATUS_DELAY_ERROR = 5,
+    LMAC154_TX_STATUS_NO_ACK      = 6,
+    LMAC154_TX_STATUS_CCA_FAILED  = 7,
+    LMAC154_TX_STATUS_MAX         = 8,
+}lmac154_tx_status_t;
+
+typedef enum {
+    LMAC154_RX_REJECT_CRC_ERR            = 0x00000001, /* will reject packets that CRC check error */
+    LMAC154_RX_REJECT_FRAME_TYPE_RVSD    = 0x00000002, /* will reject packets that the value of frame type filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_FRAME_VER_RVSD     = 0x00000004, /* will reject packets that the value of frame version filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_DST_ADDR_M_RVSD    = 0x00000008, /* will reject packets that the value of dest address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_SRC_ADDR_M_RVSD    = 0x00000010, /* will reject packets that the value of src address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_DST_PANID_MISMATCH = 0x00000020, /* will reject packets that the value of dest PANID does not match with local device */
+    LMAC154_RX_REJECT_DST_ADDR_MISMATCH  = 0x00000040, /* will reject packets that the value of dest address does not match with local device */
+    LMAC154_RX_REJECT_SRC_PANID_MISMATCH = 0x00000080, /* will reject packets that the value of src PANID does not match with local device */
+
+    LMAC154_RX_REJECT_NONE               = 0x00000000, /* will not reject all packets above */
+    LMAC154_RX_REJECT_ALL                = 0x000000ff, /* will reject all packets above */
+}lmac154_rx_reject_policy_t;
+
+typedef enum {
+    LMAC154_RX_ACCEPT_CRC_ERR            = 0x00000001, /* able to receive packets that CRC check error */
+    LMAC154_RX_ACCEPT_FRAME_TYPE_RVSD    = 0x00000002, /* able to receive packets that the value of frame type filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_FRAME_VER_RVSD     = 0x00000004, /* able to receive packets that the value of frame version filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_DST_ADDR_M_RVSD    = 0x00000008, /* able to receive packets that the value of dest address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_SRC_ADDR_M_RVSD    = 0x00000010, /* able to receive packets that the value of src address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_DST_PANID_MISMATCH = 0x00000020, /* able to receive packets that the value of dest PANID does not match with local device */
+    LMAC154_RX_ACCEPT_DST_ADDR_MISMATCH  = 0x00000040, /* able to receive packets that the value of dest address does not match with local device */
+    LMAC154_RX_ACCEPT_SRC_PANID_MISMATCH = 0x00000080, /* able to receive packets that the value of src PANID does not match with local device */
+
+    LMAC154_RX_ACCEPT_NONE               = 0x00000000, /* not able to receive all packets above */
+    LMAC154_RX_ACCEPT_ALL                = 0x000000ff, /* able to receive all packets above */
+}lmac154_rx_accept_policy_t;
+
+typedef enum {
+    lmac154_addr_info_none               = 0x00000000,
+    lmac154_addr_info_panid              = 0x00000001,
+    lmac154_addr_info_short_addr         = 0x00000002,
+    lmac154_addr_info_ext_addr           = 0x00000004,
+    lmac154_addr_info_panid_short_addr   = lmac154_addr_info_panid | lmac154_addr_info_short_addr,
+    lmac154_addr_info_panid_ext_addr     = lmac154_addr_info_panid | lmac154_addr_info_ext_addr,
+} lmac154_addr_info_t;
+
+typedef void (*lmac154_txDoneCallback_t)(lmac154_tx_status_t, uint32_t *, uint32_t);
+
+/**
+ * @brief RX callback status codes
+ */
+typedef enum {
+    LMAC154_RX_STATUS_NONE          = 0,
+    LMAC154_RX_STATUS_RX_DONE       = 1,
+    LMAC154_RX_STATUS_ACK_SENT      = 2,
+    LMAC154_RX_STATUS_ACK_ERR       = 3,
+} lmac154_rx_status_t;
+
+typedef struct lmac154_receiveInfo lmac154_receiveInfo_t;
+
+typedef void (*lmac154_rxDoneCallback_t)(lmac154_rx_status_t, lmac154_receiveInfo_t *, uint32_t *);
+
+struct lmac154_receiveInfo {
+    uint32_t                        rx_length:8;
+    uint32_t                        nbr_idx:8;
+    uint32_t                        mac_hdr_size:8;
+    uint32_t                        is_tx_acking:1;
+    uint32_t                        is_enh_ack_requested:1;
+    uint32_t                        is_frame_pended:1;
+    uint32_t                        is_src_saddr:1;
+    uint32_t                        is_src_xaddr:1;
+    uint32_t                        stack_msk:2;
+    uint32_t                        unused:1;
+    uint16_t                        rx_error;
+    uint8_t                         enh_ack_time;
+    uint8_t                         dbg_en:1;
+    uint8_t                         dbg_rx_filter_en:1;
+    uint8_t                         dbg_ack_len:6;
+    int8_t                          dbg_ack_cost;
+    int8_t                          dbg_csl_drift_ack;
+    uint16_t                        dbg_csl_ack_phase;
+    uint32_t                        rx_done_symbol_cnt;
+    union {
+        uint16_t                    saddr;
+        uint32_t                    xaddr[2];
+        uint8_t                     addr[8];
+    } src_addr;
+    lmac154_rxDoneCallback_t        callback[2];
+};
+
+/****************************************************************************
+ * @brief  lmac154 stack index enumeration
+ *
+ ******************************************************************************/
+typedef enum {
+    LMAC154_STACK_1 = 0,  /**< First stack (default for single stack mode) */
+    LMAC154_STACK_2 = 1,  /**< Second stack (for dual stack mode) */
+} lmac154_stack_idx_t;
+
+typedef struct {
+    uint32_t *                      key;
+    uint8_t                         a_data_length;
+    uint8_t                         m_data_length;
+    struct {
+        uint32_t                    ext_addr[2];
+        uint32_t                    frame_cnt;
+        uint8_t                     security_level;
+    }                               nonce;
+    uint32_t *                      a_data;      /* Authentication data (header) */
+    uint32_t *                      m_data;      /* Message data */
+    uint32_t *                      c_data;      /* Encrypted output buffer */
+} lmac154_security_t;
+
+typedef struct {
+    uint32_t                        base_time;
+    uint32_t                        delay_time;
+} lmac154_tx_timing_t;
+
+typedef struct {
+    uint8_t                         csl_retry;
+    uint8_t                         csl_ie_offset;
+    uint16_t                        csl_period;
+    uint32_t                        csl_sample_time;
+    int8_t                          csl_tx_offset_sym_cnt;
+    int8_t                          dbg_csl_drift_tx;
+    uint16_t                        dbg_csl_tx_phase;
+} lmac154_csl_opt_t;
+
+typedef struct __lmac154_txParam_ext {
+    uint32_t *                      pkt;
+    uint32_t                        pkt_length:8;
+    uint32_t                        tx_channel:4;
+    uint32_t                        resume_channel:4;
+    uint32_t                        csma_ca_max_backoff:4;
+    uint32_t                        is_cca:1;
+    uint32_t                        is_ack_required:1;
+    uint32_t                        is_enh_ack_required:1;
+    uint32_t                        is_tx_doing:1;
+    uint32_t                        is_last_tx:1;
+    uint32_t                        is_base_param:1;
+    uint32_t                        is_tx_security:1;
+    uint32_t                        unused:5;
+    uint32_t                        ack_rx_done_symbol_cnt;
+    lmac154_txDoneCallback_t        tx_done_cb;
+    struct __lmac154_txParam_ext *  next;
+
+    lmac154_security_t              sec;
+    lmac154_tx_timing_t             tx_timing;
+    lmac154_csl_opt_t               csl_opt;
+#if CONFIG_LMAC154_DBG
+    uint32_t                        dbg_plat_entry_sym;
+#endif
+} lmac154_txParam_ext_t;
+
+typedef struct __lmac154_txParam {
+    uint32_t *                      pkt;
+    uint32_t                        pkt_length:8;
+    uint32_t                        tx_channel:4;
+    uint32_t                        resume_channel:4;
+    uint32_t                        csma_ca_max_backoff:4;
+    uint32_t                        is_cca:1;
+    uint32_t                        is_ack_required:1;
+    uint32_t                        is_enh_ack_required:1;
+    uint32_t                        is_tx_doing:1;
+    uint32_t                        is_last_tx:1;
+    uint32_t                        is_base_param:1;
+    uint32_t                        unused:6;
+    uint32_t                        ack_rx_done_symbol_cnt;
+    lmac154_txDoneCallback_t        tx_done_cb;
+    struct __lmac154_txParam_ext *  next;
+} lmac154_txParam_t;
+
+/* Frame control constants and macros have been moved to lmac154_frame.h */
+
+/****************************************************************************
+ * @brief  Initialize the hardware module
+ *         Call this function first
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_init(void);
+
+/****************************************************************************
+ * @brief  Enable MAC 15.4 2015 standard feature
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015(bool isEnable);
+
+/****************************************************************************
+ * @brief  Enable MAC 15.4 2015 standard feature with extra configuration
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015Extra(bool isEnable);
+
+/****************************************************************************
+ * @brief  Enable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable1stStack(void);
+
+/****************************************************************************
+ * @brief  Disable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable1stStack(void);
+
+/****************************************************************************
+ * @brief  Enable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable1stStack(void);
+
+/****************************************************************************
+ * @brief  Disable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable1stStack(void);
+
+/****************************************************************************
+ * @brief  Enable second stack for dual stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2ndStack(void);
+
+/****************************************************************************
+ * @brief  Disable second stack for dual stack, which is disable by default
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2ndStack(void);
+
+/****************************************************************************
+ * @brief  Check whether the second stack is enabled
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+uint32_t lmac154_is2ndStackEnabled(void);
+
+/****************************************************************************
+ * @brief  Get whether lmac154 is disabled
+ *
+ * @param  None
+ *
+ * @return 1 for disabled, 0 for enabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isDisabled(void);
+
+/****************************************************************************
+ * @brief  Monitor the hardware state
+ *
+ * @param  monitor_timeout, monitor timeout in ms
+ *
+ * @return monitor result
+ *
+*******************************************************************************/
+int lmac154_monitor(uint32_t monitor_timeout);
+
+/****************************************************************************
+ * @brief  Get the lmac154 interrupt handler for interrupt registration of M154_IRQn
+ *
+ * @param  None
+ *
+ * @return The lmac154 interrupt handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptHandler(void);
+
+/****************************************************************************
+ * @brief  Register rx done event callback for specific stack and get m154 irq handler
+ *
+ * @param  stack_idx, which stack to register (LMAC154_STACK_1 or LMAC154_STACK_2)
+ * @param  stack_rxDoneCallback, frame received callback function
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+bool lmac154_registerEventCallback(lmac154_stack_idx_t stack_idx,
+                                   lmac154_rxDoneCallback_t stack_rxDoneCallback);
+
+/****************************************************************************
+ * @brief  Register rx done event callback and get m154 irq handler
+ *
+ * @param  stack1_rxDoneCallback, frame received with destination panid on stack 1
+ *
+ * @param  stack2_rxDoneCallback, frame received with destination panid on stack 2
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptCallback(void);
+
+/****************************************************************************
+ * @brief  Get the version number
+ *
+ * @param  None
+ *
+ * @return The library version number
+ *
+*******************************************************************************/
+uint32_t lmac154_getVersionNumber(void);
+
+/****************************************************************************
+ * @brief  Get the version number string
+ *
+ * @param  None
+ *
+ * @return The library version number string
+ *
+*******************************************************************************/
+char * lmac154_getVersionString(void);
+
+/****************************************************************************
+ * @brief  Enable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer accepts all frames received from the PHY layer
+ *         Able to receive frames without any IFS but rx sensitivity may be degraded if enhanced_mode = 1
+ *         The MPDU is unavailable in lmac154_rxDoneEvent if ignore_mpdu = 1
+ *
+ * @param  enhanced_mode: 0: standard mode, 1: enhanced mode
+ * @param  ignore_mpdu: 0: read mpdu from registers, 1: do not read mpdu from registers
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxPromiscuousMode(uint8_t enhanced_mode, uint8_t ignore_mpdu);
+
+/****************************************************************************
+ * @brief  Disable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer only accepts frames that pass the address filtering
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxPromiscuousMode(void);
+
+/****************************************************************************
+ * @brief  Get whether rx promiscuous mode is enabled
+ *
+ * @param  None
+ *
+ * @return 1 for enabled; 0 for disabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isRxPromiscuousModeEnabled(void);
+
+/****************************************************************************
+ * @brief  Enable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRx(void);
+
+/****************************************************************************
+ * @brief  try to force enable rx
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_forceEnableRX(void);
+
+/****************************************************************************
+ * @brief  Disable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRx(void);
+
+/****************************************************************************
+ * @brief  Set rx on/off state when idle state
+ *
+ * @param  isRxOnWhenIdle: true is rx on when idle; otherwhile is rx off when idle
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxStateWhenIdle(bool isRxOnWhenIdle);
+
+/****************************************************************************
+ * @brief  Get rx on/off state when idle state
+ *
+ * @param  None
+ *
+ * @return true is rx on when idle; otherwhile is rx off when idle
+ *
+*******************************************************************************/
+bool lmac154_isRxStateWhenIdle(void);
+
+/****************************************************************************
+ * @brief  Set the number of maximum retransmission times (default 0)
+ *         Will perform retransmission in case ack is not received if num > 0
+ *         Will raise lmac154_ackEvent(ack_received = 0) after maximum retransmission times
+ *
+ * @param  num: number of maximum retransmission times
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRetry(uint32_t num);
+
+/****************************************************************************
+ * @brief  Trigger TX
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma: 0: without CSMA, 1: with CSMA
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_triggerTx(uint8_t *DataPtr, uint8_t length, uint8_t csma);
+
+/****************************************************************************
+ * @brief  Trigger TX with base parameter set (no CSL/extended options).
+ *         Wraps lmac154_triggerParamTxExt with is_base_param flag set.
+ *         Must be called within critical section.
+ *
+ * @param  txParam: pointer to lmac154_txParam_t
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTx(lmac154_txParam_t * txParam);
+
+/****************************************************************************
+ * @brief  Trigger TX with extended parameter set.
+ *         Performs CSMA-CA backoff (hardware or software), sets up the MPDU,
+ *         configures CSL IE if applicable, and triggers the radio transmit.
+ *         Must be called within critical section.
+ *
+ * @param  txParam: pointer to lmac154_txParam_ext_t
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTxExt(lmac154_txParam_ext_t * txParam);
+
+/****************************************************************************
+ * @brief  Encrypt packet using AES-CCM with parameters from lmac154_security_t
+ *
+ * Supports frames with or without payload (e.g., enhanced ACK with only header).
+ *
+ * @param  param: pointer to lmac154_security_t containing encryption parameters
+ *                - key: AES key pointer [required]
+ *                - nonce: nonce (ext_addr, frame_cnt, key_id) [required]
+ *                - security_level: security level (determines MIC length) [required]
+ *                - a_data: authentication data (header, plaintext) [required]
+ *                - m_data: message data (plaintext) [optional, can be NULL]
+ *                - c_data: output buffer for encrypted message + MIC [required]
+ *                - a_data_length: length of authentication data [required]
+ *                - m_data_length: length of message data (0 if no payload) [optional]
+ *
+ * @return Encrypted message length + MIC length on success (if m_data_length=0, returns MIC length only),
+ *         negative error code on failure
+ *
+ *******************************************************************************/
+int32_t lmac154_encryptPacket(lmac154_security_t * param);
+
+/****************************************************************************
+ * @brief  Write TX ack frame to mpdu buffer to send in lmac154_receivedEvent
+ *         with isEnhAckExpected true.
+ *
+ * @param  ack_frame: pointer to data buffer of ack frame
+ * @param  ack_frame_length: data length in bytes
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_writeTxAckFrame(uint8_t *ack_frame, int ack_frame_length);
+
+/****************************************************************************
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerParamTx
+ *         is called with time specified
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 1 is selected
+ *
+*******************************************************************************/
+uint32_t lmac154_isTriggerTimeSelected(void);
+
+/****************************************************************************
+ * @brief  Run tx continuous modulation (PRBS15 pattern)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCM(void);
+
+#if defined(BL702) || defined(BL702L)
+/****************************************************************************
+ * @brief  Run tx continuous wave (single tone)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCW(void);
+#endif
+
+/****************************************************************************
+ * @brief  Reset tx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetTx(void);
+
+/****************************************************************************
+ * @brief  Reset rx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetRx(void);
+
+/****************************************************************************
+ * @brief  Set the channel (default LMAC154_CHANNEL_11)
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setChannel(lmac154_channel_t ch_ind);
+
+/****************************************************************************
+ * @brief  Get the channel
+ *
+ * @param  None
+ *
+ * @return The channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+*******************************************************************************/
+lmac154_channel_t lmac154_getChannel(void);
+
+/****************************************************************************
+ * @brief  Get RSSI in dBm
+ *
+ * @param  None
+ *
+ * @return RSSI in dBm
+ *
+*******************************************************************************/
+int lmac154_getRSSI(void);
+
+/****************************************************************************
+ * @brief  Get LQI
+ *
+ * @param  None
+ *
+ * @return LQI
+ *
+*******************************************************************************/
+int lmac154_getLQI(void);
+
+/****************************************************************************
+ * @brief  Get SFD correlation
+ *
+ * @param  None
+ *
+ * @return SFD correlation
+ *
+*******************************************************************************/
+uint8_t lmac154_getSFDCorrelation(void);
+
+/****************************************************************************
+ * @brief  Get the frequency offset in Hz
+ *
+ * @param  None
+ *
+ * @return The frequency offset in Hz
+ *
+*******************************************************************************/
+int lmac154_getFrequencyOffset(void);
+
+/****************************************************************************
+ * @brief  Set country code for tx power adjustment
+ *
+ * @param  country_code: country code, for example: CN
+ *
+ * @return true, if country code is valid.
+ *
+*******************************************************************************/
+bool lmac154_setCountryCode(const char * country_code);
+
+/****************************************************************************
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPower(lmac154_tx_power_t power_dbm);
+
+/****************************************************************************
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @param country_code: country code, for example: CN
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPowerWithPowerLimit(lmac154_tx_power_t power_dbm, lmac154_channel_t ch_ind, const char *country_code);
+
+/****************************************************************************
+ * @brief  Get tx power
+ *
+ * @param  None
+ *
+ * @return tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+*******************************************************************************/
+lmac154_tx_power_t lmac154_getTxPower(void);
+
+/****************************************************************************
+ * @brief  Set tx data rate (default LMAC154_DATA_RATE_250K)
+ *         The maximum tx mpdu length is 127 bytes for 250kbps tx data rate, and 255 bytes for others
+ *
+ * @param  rate: LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxDataRate(lmac154_data_rate_t rate);
+
+/****************************************************************************
+ * @brief  Enable auto rx data rate (default disabled)
+ *         The maximum rx mpdu length is 127 bytes for 250kbps rx data rate, and 255 bytes for others
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAutoRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Disable auto rx data rate (default disabled)
+ *         The rx data rate is 250kbps, and the maximum rx mpdu length is 127 bytes
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAutoRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Get rx data rate
+ *
+ * @param  None
+ *
+ * @return LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+*******************************************************************************/
+lmac154_data_rate_t lmac154_getRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Set CCA mode (default LMAC154_CCA_MODE_ED_AND_CS)
+ *
+ * @param  mode: LMAC154_CCA_MODE_ED, LMAC154_CCA_MODE_CS, LMAC154_CCA_MODE_ED_AND_CS, or LMAC154_CCA_MODE_ED_OR_CS
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCCAMode(lmac154_cca_mode_t mode);
+
+/****************************************************************************
+ * @brief  Set CCA ED threshold (default -71dBm)
+ *
+ * @param  threshold: ED threshold ranging from -122 to 5 in dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEDThreshold(int threshold);
+
+/****************************************************************************
+ * @brief  Get CCA ED threshold
+ *
+ * @param  None
+ *
+ * @return ED threshold
+ *
+*******************************************************************************/
+int lmac154_getEDThreshold(void);
+
+/****************************************************************************
+ * @brief  Run CCA
+ *
+ * @param  rssi: rssi output ranging from -122 to 5 in dBm
+ *
+ * @return CCA result: 0: channel idle, 1: channel busy
+ *
+*******************************************************************************/
+uint8_t lmac154_runCCA(int *rssi);
+
+/****************************************************************************
+ * @brief  Set PAN ID (default 0x4321)
+ *
+ * @param  pid: PAN ID
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setPanId(uint16_t pid);
+void lmac154_set2ndPanId(uint16_t pid);
+
+/****************************************************************************
+ * @brief  Get PAN ID
+ *
+ * @param  None
+ *
+ * @return PAN ID
+ *
+*******************************************************************************/
+uint16_t lmac154_getPanId(void);
+uint16_t lmac154_get2ndPanId(void);
+
+/****************************************************************************
+ * @brief  Set 16-bit short address (default 0x0000)
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setShortAddr(uint16_t sadr);
+void lmac154_set2ndShortAddr(uint16_t sadr);
+
+/****************************************************************************
+ * @brief  Get 16-bit short address
+ *
+ * @param  None
+ *
+ * @return 16-bit short address
+ *
+*******************************************************************************/
+uint16_t lmac154_getShortAddr(void);
+uint16_t lmac154_get2ndShortAddr(void);
+
+/****************************************************************************
+ * @brief  Set 64-bit long address (default 0xACDE4800_00000002)
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setLongAddr(uint8_t *ladr);
+void lmac154_set2ndLongAddr(uint8_t *ladr);
+
+/****************************************************************************
+ * @brief  Get 64-bit long address
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getLongAddr(uint8_t *ladr);
+void lmac154_get2ndLongAddr(uint8_t *ladr);
+
+/****************************************************************************
+ * @brief  Enable frame type filtering (default disabled)
+ *         Will only receive specified frame types
+ *
+ * @param  frame_types: any combination of LMAC154_FRAME_TYPE_XXX (BEACON, DATA, ACK, or CMD), via bitwise OR ('|') operation
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableFrameTypeFiltering(uint8_t frame_types);
+
+/****************************************************************************
+ * @brief  Disable frame type filtering (default disabled)
+ *         Will receive all valid frame types (BEACON, DATA, ACK, or CMD)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableFrameTypeFiltering(void);
+
+/****************************************************************************
+ * @brief  Set rx reject policy
+ *
+ * @param policy : enum lmac154_rx_reject_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxRejectPolicy(lmac154_rx_reject_policy_t policy);
+
+/****************************************************************************
+ * @brief  Get rx reject policy
+ *
+ * @param None
+ *
+ * @return Rx reject policy
+ *
+*******************************************************************************/
+lmac154_rx_reject_policy_t lmac154_getRxRejectPolicy(void);
+
+/****************************************************************************
+ * @brief  set rx accept policy
+ *
+ *
+ * @param policy : enum lmac154_rx_accept_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxAcceptPolicy(lmac154_rx_accept_policy_t policy);
+
+/****************************************************************************
+ * @brief  get rx accept policy
+ *
+ *
+ * @param None
+ *
+ * @return lmac154_rx_accept_policy : enum lmac154_rx_accept_policy_t
+ *
+*******************************************************************************/
+lmac154_rx_accept_policy_t lmac154_getRxAcceptPolicy(void);
+
+#ifdef BL702
+/****************************************************************************
+ * @brief  Set external PA
+ *         Restriction: txpin % 5 != rxpin % 5
+ *
+ * @param  txpin: tx pin ranging from 0 to 31
+ * @param  rxpin: rx pin ranging from 0 to 31
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setExtPA(uint32_t txpin, uint32_t rxpin);
+#endif
+
+/****************************************************************************
+ * @brief  Get RF state
+ *
+ * @param  None
+ *
+ * @return LMAC154_RF_STATE_RX, LMAC154_RF_STATE_RX_DOING, LMAC154_RF_STATE_TX, or LMAC154_RF_STATE_IDLE
+ *
+*******************************************************************************/
+lmac154_rf_state_t lmac154_getRFState(void);
+
+/****************************************************************************
+ * @brief  Enable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableCoex(void);
+
+/****************************************************************************
+ * @brief  Disable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableCoex(void);
+
+/****************************************************************************
+ * @brief  Check if coexistence is enabled
+ *
+ * @param  None
+ *
+ * @return true if coexistence is enabled, false otherwise
+ *
+ *******************************************************************************/
+bool lmac154_isCoexEnabled(void);
+
+/****************************************************************************
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCoexPriority(bool is_rx_on_after_rx_abort_enable, uint32_t tx_priority,
+    uint32_t rx_unicast_priority, uint32_t rx_sfd_priority, uint32_t rx_idle_priority);
+
+/****************************************************************************
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getCoexPriority(bool * is_rx_on_after_rx_abort_enable, uint32_t * tx_priority,
+    uint32_t * rx_unicast_priority, uint32_t * rx_sfd_priority, uint32_t * rx_idle_priority);
+
+/****************************************************************************
+ * @brief  Enable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableTxAbortInt(void);
+
+/****************************************************************************
+ * @brief  Disable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableTxAbortInt(void);
+
+/****************************************************************************
+ * @brief  Enable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableHwAutoTxAck(void);
+
+/****************************************************************************
+ * @brief  Disable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableHwAutoTxAck(void);
+
+/****************************************************************************
+ * @brief  Get whether hardware auto transmission of ack frame is enabled
+ *
+ * @param  None
+ *
+ * @return ture, enabled
+ *
+*******************************************************************************/
+bool lmac154_isHwAutoTxAckEnabled(void);
+
+/****************************************************************************
+ * @brief  Enable lmac154_ackEvent (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAckEvent(void);
+
+/****************************************************************************
+ * @brief  Disable lmac154_ackEvent (default enabled)
+ *         Will raise lmac154_rxDoneEvent instead when ack is received
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAckEvent(void);
+
+/****************************************************************************
+ * @brief  Enable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Disable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Enable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxMHREvent(void);
+
+/****************************************************************************
+ * @brief  Disable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxMHREvent(void);
+
+/****************************************************************************
+ * @brief  Enable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxSecMHREvent(void);
+
+/****************************************************************************
+ * @brief  Disable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxSecMHREvent(void);
+
+/****************************************************************************
+ * @brief  Enable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableReqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Disable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableReqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Get the receiving or received mpdu length in bytes (crc included)
+ *
+ * @param  None
+ *
+ * @return The receiving or received mpdu length
+ *
+*******************************************************************************/
+uint8_t lmac154_getRxLength(void);
+
+/****************************************************************************
+ * @brief  Read rx data (crc not included)
+ *
+ * @param  buf: pointer to data buffer
+ * @param  offset: data offset ranging from 0 to 252 in bytes
+ * @param  len: data length ranging from 1 to 253-offset in bytes
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxData(uint8_t *buf, uint8_t offset, uint8_t len);
+
+/****************************************************************************
+ * @brief  Read rx crc
+ *
+ * @param  crc: byte array to carry rx crc
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxCrc(uint8_t crc[2]);
+
+/****************************************************************************
+ * @brief  Set the maximum wait time for ack frame (default 864us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setAckWaitTime(uint16_t time_us);
+
+/****************************************************************************
+ * @brief  Get the maximum wait time for imm-ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getAckWaitTime(void);
+
+/****************************************************************************
+ * @brief  Set the maximum wait time for enh-ack ack frame (default 1500us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEnhAckWaitTime(uint16_t time_us);
+
+/****************************************************************************
+ * @brief  Get the maximum wait time for enh-ack ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getEnhAckWaitTime(void);
+
+/****************************************************************************
+ * @brief  Set the maximum and minimum CSMA-CA backoff exponent
+ *
+ * @param  max_be: maximum BE ranging from 3 to 8, default 5
+ * @param  min_be: minimum BE ranging from 0 to max_be, default 3
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setBE(uint8_t max_be, uint8_t min_be);
+
+/****************************************************************************
+ * @brief  Set maximum CSMA backoff
+ *
+ * @param  maxBackoff: maximum CSMA backoff
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setMaxCsmaBackoff(uint8_t maxBackoff);
+
+/****************************************************************************
+ * @brief  Set tx-rx transition time
+ *
+ * @param  time: us
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRxTransTime(uint8_t timeInUs);
+
+/****************************************************************************
+ * @brief  Enable Rx filtering (default enabled)
+ *         Will only receive frames that pass crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxFiltering(void);
+
+/****************************************************************************
+ * @brief  Disable rx filtering (default enabled)
+ *         Will receive all frames ignoring crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxFiltering(void);
+
+/****************************************************************************
+ * @brief  Enable/Disable rx filtering (default enabled) for dual stacks
+ *         Will receive all frames ignoring crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxFiltering(bool is_enable);
+
+uint64_t lmac154_get_rx_start_timestamp(void);
+uint64_t lmac154_get_rx_done_timestamp(void);
+uint64_t lmac154_get_tx_done_timestamp(void);
+
+#if defined (BL702) || defined (BL702L) || defined (BL616)
+bool lmac154_fptSetMaxNum(uint32_t shortAddrNum, uint32_t longAddrNum);
+#endif
+
+/****************************************************************************
+ * @brief  Run AES CCM
+ *
+ * @param  mode: LMAC154_AES_MODE_ENCRYPT or LMAC154_AES_MODE_DECRYPT
+ * @param  a_data: pointer to additional authentication data buffer
+ * @param  a_len: length of additional authentication data in bytes
+ * @param  nonce: pointer to 13-byte nonce buffer
+ * @param  key: pointer to 4-word key buffer
+ * @param  mic_len: LMAC154_MIC_LEN_4, LMAC154_MIC_LEN_8, LMAC154_MIC_LEN_12, or LMAC154_MIC_LEN_16
+ * @param  mic: pointer to mic buffer
+ * @param  input_data: pointer to input data buffer
+ * @param  output_data: pointer to output data buffer
+ * @param  len: length of input data in bytes
+ *
+ * @return The error code
+ *
+*******************************************************************************/
+lmac154_aes_status_t lmac154_runAESCCM(lmac154_aes_mode_t mode,
+                                       const uint8_t *a_data,
+                                       uint8_t a_len,
+                                       const uint8_t *nonce,
+                                       const uint32_t *key,
+                                       lmac154_aes_mic_len_t mic_len,
+                                       uint32_t *mic,
+                                       const uint32_t *input_data,
+                                       uint32_t *output_data,
+                                       uint8_t len);
+
+/* hardware frame pending table (256 bytes) */
+/* shared by short addresses and long addresses (supports up to 128 short addresses or 32 long addresses or mixed) */
+/* used by hardware to set the frame pending bit of hw auto tx ack */
+/* if the address is not found in the table (e.g. not set or removed), the frame pending bit of hw auto tx ack is 1 */
+
+/****************************************************************************
+ * @brief  Add (or update) the key-value pair {sadr: pending} to (in) the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetShortAddrPending(uint16_t sadr, uint8_t pending);
+
+/****************************************************************************
+ * @brief  Add (or update) the key-value pair {ladr: pending} to (in) the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetLongAddrPending(uint32_t *xaddr, uint8_t pending);
+
+/****************************************************************************
+ * @brief  Get the corresponding frame pending bit of the short address in the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetShortAddrPending(uint16_t sadr, uint8_t *pending);
+
+/****************************************************************************
+ * @brief  Get the corresponding frame pending bit of the long address in the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetLongAddrPending(uint32_t *xaddr, uint8_t *pending);
+
+/****************************************************************************
+ * @brief  Remove the key-value pair {sadr: pending} from the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveShortAddr(uint16_t sadr);
+
+/****************************************************************************
+ * @brief  Remove the key-value pair {ladr: pending} from the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveLongAddr(uint32_t *ladr);
+
+/****************************************************************************
+ * @brief  Get short address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetShortAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************
+ * @brief  Get long address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetLongAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************
+ * @brief  Set frame pending bit according to frame pending table, or force to set to 1
+ *
+ * @param  force: 0: set according to frame pending table (default), 1: force to set to 1
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptForcePending(uint8_t force);
+
+/****************************************************************************
+ * @brief  Clear the frame pending table
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptClear(void);
+
+/****************************************************************************
+ * @brief  Print the frame pending table using specified print function
+ *
+ * @param  print_func: user specified print function
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptDump(int print_func(const char *fmt, ...));
+
+/* functions below are callback functions running in the interrupt context */
+/* should be implemented by user if needed */
+
+/****************************************************************************
+ * @brief  Tx Done Event
+ *         Will be raised after calling lmac154_triggerTx
+ *
+ * @param  tx_status: LMAC154_TX_STATUS_XXX (TX_FINISHED, CSMA_FAILED, TX_ABORTED, or HW_ERROR)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_txDoneEvent(lmac154_tx_status_t tx_status);
+
+/****************************************************************************
+ * @brief  Ack Event
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  frame_pending: frame pending bit in ack frame
+ * @param  seq_num: sequence number in ack frame
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackEvent(uint8_t ack_received, uint8_t frame_pending, uint8_t seq_num);
+
+/****************************************************************************
+ * @brief  Ack Event with ack frame
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  rx_buf: pointer to the ack frame buffer
+ * @param  len: ACK frame length
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackFrameEvent(uint8_t ack_received, uint8_t *rx_buf, uint8_t len);
+
+/****************************************************************************
+ * @brief  Rx Done Event
+ *         Will be raised when a frame is received on lmac154_getInterruptHandler used
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received mpdu length in bytes (crc included)
+ * @param  crc_fail: 0: crc pass, 1: crc fail
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxDoneEvent(uint8_t *rx_buf, uint8_t rx_len, uint32_t crc_fail);
+
+/****************************************************************************
+ * @brief  Rx Start Event
+ *         Will be raised when rx on MAC sublayer starts
+ *         lmac154_getRxLength is available because it is obtained from PHY layer
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Hardware auto tx ack done event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_hwAutoTxAckDoneEvent(void);
+
+/****************************************************************************
+ * @brief  A 2015 version unicast packet received and enh-ack is required to respond
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_reqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+/****************************************************************************
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxSecMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+#endif

--- a/include/bouffalolab/bl70x/lmac154/lmac154_fpt.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154_fpt.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FPT_H__
+#define __LMAC154_FPT_H__
+
+typedef enum {
+    LMAC154_FPT_DATAREQ             = 0,
+    LMAC154_FPT_DATAREQ_DATA        = 1,
+    LMAC154_FPT_ANY                 = 2
+} lmac154_fptMode_t;
+
+typedef enum {
+    LMAC154_FPT_RESULT_NONE         = 0,
+    LMAC154_FPT_RESULT_FALSE        = 1,
+    LMAC154_FPT_RESULT_TRUE         = 2,
+    LMAC154_FPT_RESULT_BUSY         = 3
+} lmac154_fptResult_t;
+
+typedef union {
+    struct {
+        uint32_t isExist:1;
+        uint32_t isFramePended:1;
+        uint32_t nbrIdx:7;
+        uint32_t isSearchDone:1;
+        uint32_t unused:22;
+    } bf;
+
+    uint32_t word;
+
+} lmac154_fptSearchResult_t;
+
+void lmac154_setFramePendingSourceMatch(bool isEnable);
+
+/****************************************************************************//**
+ * @brief  Set frame pending table mode
+ *
+ * @param  mode: 
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingMode(lmac154_fptMode_t mode);
+
+/****************************************************************************//**
+ * @brief  Get frame pending table mode
+ *
+ * @param  mode: frame pending table working mode
+ *
+ * @return None
+ *
+*******************************************************************************/
+lmac154_fptMode_t lmac154_getFramePendingMode(void);
+
+/****************************************************************************//**
+ * @brief  Get frame pending table result when receive a packet
+ *
+ * @param  tout, timeout to get result with macro second unit
+ * 
+ * @return Result
+ *
+*******************************************************************************/
+lmac154_fptSearchResult_t lmac154_framePendingResult(uint32_t tout);
+
+#endif

--- a/include/bouffalolab/bl70x/lmac154/lmac154_fpt.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154_fpt.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FPT_H__
+#define __LMAC154_FPT_H__
+
+typedef enum {
+    LMAC154_FPT_DATAREQ             = 0,
+    LMAC154_FPT_DATAREQ_DATA        = 1,
+    LMAC154_FPT_ANY                 = 2
+} lmac154_fptMode_t;
+
+typedef enum {
+    LMAC154_FPT_RESULT_NONE         = 0,
+    LMAC154_FPT_RESULT_FALSE        = 1,
+    LMAC154_FPT_RESULT_TRUE         = 2,
+    LMAC154_FPT_RESULT_BUSY         = 3
+} lmac154_fptResult_t;
+
+void lmac154_setFramePendingSourceMatch(bool isEnable);
+
+/****************************************************************************
+ * @brief  Set frame pending table mode
+ *
+ * @param  mode:
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingMode(lmac154_fptMode_t mode);
+
+/****************************************************************************
+ * @brief  Get frame pending table mode
+ *
+ * @param  None
+ *
+ * @return lmac154_fptMode_t
+ *
+*******************************************************************************/
+lmac154_fptMode_t lmac154_getFramePendingMode(void);
+
+/****************************************************************************
+ * @brief  Get frame pending table result when receive a packet
+ *
+ * @param  tout: timeout to do frame pending table search
+ *
+ * @param  isFramePended: whether frame pending is set for searched on received packet
+ *
+ * @return int: return the index of neighbor table if matched; else, return -1
+ *
+*******************************************************************************/
+int lmac154_framePendingResult(uint32_t tout, bool * isFramePended);
+
+#if defined BL618DG
+/****************************************************************************
+ * @brief  Set frame pending bit result if neighbor search fails
+ *
+ * @param  bFramePending, frame pending bit, true by default.
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingBitIfNeighborSearchFails(bool bFramePending);
+
+/****************************************************************************
+ * @brief  Get frame pending bit result if neighbor search fails
+ *
+ * @param  None
+ *
+ * @return True, if neighbor search fails.
+ *
+*******************************************************************************/
+bool lmac154_getFramePendingBitIfNeighborSearchFails(void);
+#endif
+#endif

--- a/include/bouffalolab/bl70x/lmac154/lmac154_frame.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154_frame.h
@@ -1,0 +1,550 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FRAME_H__
+#define __LMAC154_FRAME_H__
+
+/****************************************************************************
+ * @file lmac154_frame.h
+ * @brief IEEE 802.15.4 Frame Parsing and Analysis Module
+ ******************************************************************************/
+
+/*============================================================================
+ * Frame Control Field Definitions
+ *============================================================================*/
+
+/* Frame Type */
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK       (7)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_BEACON     (0)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA       (1)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK        (2)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD        (3)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP        (5)
+
+/* Security and Pending */
+#define LMAC154_FRAME_SECURITY_MASK                 (1 << 3)
+#define LMAC154_FRAME_FRAME_PENDING_MASK            (1 << 4)
+#define LMAC154_FRAME_ACK_REQUEST_MASK              (1 << 5)
+#define LMAC154_FRAME_PANID_COMPRESSION             (1 << 6)
+#define LMAC154_FRAME_SEQ_SUPPRESSION_MASK          (1 << 8)
+#define LMAC154_FRAME_IE_MASK                       (1 << 9)
+
+/* Addressing Fields */
+#define LMAC154_FRAME_ADDR_DEST_NONE                (0 << 10)
+#define LMAC154_FRAME_ADDR_DEST_SHORT               (2 << 10)
+#define LMAC154_FRAME_ADDR_DEST_EXT                 (3 << 10)
+#define LMAC154_FRAME_ADDR_DEST_MASK                (3 << 10)
+
+#define LMAC154_FRAME_VERSION_MASK                  (3 << 12)
+#define LMAC154_FRAME_VERSION_2003                  (0 << 12)
+#define LMAC154_FRAME_VERSION_2006                  (1 << 12)
+#define LMAC154_FRAME_VERSION_2015                  (2 << 12)
+
+#define LMAC154_FRAME_ADDR_SRC_NONE                 (0 << 14)
+#define LMAC154_FRAME_ADDR_SRC_SHORT                (2 << 14)
+#define LMAC154_FRAME_ADDR_SRC_EXT                  (3 << 14)
+#define LMAC154_FRAME_ADDR_SRC_MASK                 (3 << 14)
+
+/* MPP (Multi-Purpose Protocol) Frame Specific */
+#define LMAC154_FRAME_MPP_LONG_FRAME_BIT            (1 << 3)
+#define LMAC154_FRAME_MPP_SECURITY_BIT              (1 << 9)
+#define LMAC154_FRAME_MPP_ACK_REQ                   (1 << 14)
+
+/* Auxiliary Security Header */
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_MASK          (3 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_0             (0 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_1             (1 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_2             (2 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_3             (3 << 3)
+
+/*============================================================================
+ * Frame Check Macros
+ *============================================================================*/
+
+/* Frame Type Check */
+#define LMAC154_FRAME_IS_BEACON(x)                  (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_BEACON)
+#define LMAC154_FRAME_IS_DATA(x)                    (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA)
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+#define LMAC154_FRAME_IS_CMD(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD)
+#define LMAC154_FRAME_IS_MPP(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP)
+
+/* Security Check */
+#define LMAC154_FRAME_IS_NORMAL_SECURITY(x)         ((x & LMAC154_FRAME_SECURITY_MASK) == LMAC154_FRAME_SECURITY_MASK)
+#define LMAC154_FRAME_IS_MPP_LONG_FRAME(x)          ((x & LMAC154_FRAME_MPP_LONG_FRAME_BIT) == LMAC154_FRAME_MPP_LONG_FRAME_BIT)
+#define LMAC154_FRAME_IS_MPP_SECURITY(x)            (LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_SECURITY_BIT) == LMAC154_FRAME_MPP_SECURITY_BIT)
+#define LMAC154_FRAME_IS_SECURITY_ENABLED(x)        (LMAC154_FRAME_IS_MPP(x) ? LMAC154_FRAME_IS_MPP_SECURITY(x) : LMAC154_FRAME_IS_NORMAL_SECURITY(x))
+
+/* ACK and Pending Check */
+#define LMAC154_FRAME_IS_ACK_REQ(x)                 (((x) & LMAC154_FRAME_ACK_REQUEST_MASK) == LMAC154_FRAME_ACK_REQUEST_MASK)
+#define LMAC154_FRAME_IS_FRAME_PENDED(x)            ((x) & LMAC154_FRAME_FRAME_PENDING_MASK)
+#define LMAC154_FRAME_IS_PANID_COMPRESSED(x)        (((x) & LMAC154_FRAME_PANID_COMPRESSION) == LMAC154_FRAME_PANID_COMPRESSION)
+#define LMAC154_FRAME_IS_SEQ_SUPPRESS(x)            (((x) & LMAC154_FRAME_SEQ_SUPPRESSION_MASK) == LMAC154_FRAME_SEQ_SUPPRESSION_MASK)
+
+/* Enhanced ACK Check */
+#define LMAC154_FRAME_IS_MPP_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP(x) && LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_ACK_REQ) == LMAC154_FRAME_MPP_ACK_REQ)
+#define LMAC154_FRAME_IS_ENH_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP_ACK_REQ(x) || (LMAC154_FRAME_IS_ACK_REQ(x) && LMAC154_FRAME_IS_FRAME_2015(x)))
+#define LMAC154_FRAME_IS_IMM_ACK_REQ(x)             (LMAC154_FRAME_IS_ACK_REQ(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* Frame Version Check */
+#define LMAC154_FRAME_IS_FRAME_2015(x)              (((x) & LMAC154_FRAME_VERSION_MASK) == LMAC154_FRAME_VERSION_2015)
+#define LMAC154_FRAME_IS_IE_EXIST(x)                (((x) & LMAC154_FRAME_IE_MASK) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* ACK Type Check */
+#define LMAC154_FRAME_IS_IMM_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_ENH_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* Address Type Extraction */
+#define LMAC154_FRAME_GET_DST_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_DEST_MASK)
+#define LMAC154_FRAME_GET_SRC_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_SRC_MASK)
+
+typedef struct {
+    uint8_t sec_lvl:3;
+    uint8_t key_id_mode:2;
+    uint8_t frame_counter_sup:1;
+    uint8_t asn_in_nonce:1;
+    uint8_t reserved:1;
+    uint8_t frame_cnt[4];
+    uint8_t key_id[8];
+} __packed lmac154_aux_hdr_t;
+
+typedef struct {
+    uint16_t length:7;
+    uint16_t element_id:8;
+    uint16_t type:1;
+} __packed lmac154_ie_hdr_t;
+
+typedef union {
+    struct {
+        lmac154_ie_hdr_t hdr;
+        uint16_t phase;
+        uint16_t period;
+    } __packed bf;
+    uint8_t bytes[6];
+} __packed lmac154_ie_csl_t;
+
+#define LMAC154_LIFS                    40
+#define LMAC154_SIFS                    12
+#define LMAC154_AIFS                    LMAC154_SIFS
+#define LMAC154_SIFS_MAX_FRAME_SIZE     18
+#define LMAC154_TURNAROUND              12
+#define LMAC154_PKT_MAX_LEN             127
+#define LMAC154_PREAMBLE_LEN            8
+#define LMAC154_SHR_LEN                 10
+#define LMAC154_US_PER_SYMBOL           16
+#define LMAC154_US_PER_SYMBOL_BITS      4
+
+#define LMAC154_CSMA_CA_MIN_BE          3
+#define LMAC154_CSMA_CA_MAX_BE          5
+#define LMAC154_CSMA_CA_MAX_BACKOFF     4
+
+/* Key ID Mode definitions */
+#define LMAC154_KEY_ID_MODE_0                 0
+#define LMAC154_KEY_ID_MODE_1                 1
+#define LMAC154_KEY_ID_MODE_2                 2
+#define LMAC154_KEY_ID_MODE_3                 3
+#define LMAC154_KEY_ID_MODE_4                 4
+
+/* Key ID lengths for different modes */
+#define LMAC154_KEY_ID_LEN_MODE_0             0
+#define LMAC154_KEY_ID_LEN_MODE_1             1
+#define LMAC154_KEY_ID_LEN_MODE_2             5
+#define LMAC154_KEY_ID_LEN_MODE_3             8
+#define LMAC154_KEY_ID_LEN_MODE_4_MIN         0
+#define LMAC154_KEY_ID_LEN_MODE_4_MAX         9
+
+/* IE (Information Element) Definitions */
+#define LMAC154_IE_TERmination2_ID              0x7f
+#define LMAC154_IE_CSL_ID                       0x1a
+
+/* Thread Vendor IE Definitions */
+#define LMAC154_IE_VENDOR_ID                    0x00
+#define LMAC154_IE_THREAD_VENDOR_ID             0x00
+#define LMAC154_IE_THREAD_ENH_ACK_PROBING_IE_ID 0x00
+#define LMAC154_IE_THREAD_HDR_SIZE              4
+
+/**
+ * @brief  32-bit optimized MAC Header parser.
+ * @note   Assumes 'pr' (buffer start) is 32-bit aligned.
+ * Uses single-word access to minimize bus cycles and branch mispredictions.
+ * * @param pr           Pointer to the start of the MAC frame (FCF).
+ * @param a_dest_panid Output pointer to Destination PAN ID.
+ * @param a_dest_sa    Output pointer to Destination Short Address.
+ * @param a_dest_xa    Output pointer to Destination Extended Address.
+ * @param a_src_sa     Output pointer to Source Short Address.
+ * @param a_src_xa     Output pointer to Source Extended Address.
+ */
+static inline uint32_t lmac154_parse_mhr(uint8_t *pr, uint8_t **a_dest_panid, uint8_t **a_dest_sa,
+                                 uint8_t **a_dest_xa, uint8_t **a_src_sa, uint8_t **a_src_xa)
+{
+    /* 1. Single 32-bit load to fetch FCF, Seq, and the start of Dest PAN ID.
+     * This is significantly faster than multiple 8-bit loads on 32-bit architectures. */
+    uint32_t head = *(const uint32_t *)pr;
+    uint32_t fcf  = head & 0xFFFF;
+
+    /* Initial offset: FCF(2) + Sequence Number(1) = 3 */
+    uint32_t offset = 3;
+
+    /* Extract Address Modes and PAN ID Compression bit via bit-shifting */
+    uint32_t dst_mode  = (fcf >> 10) & 0x03;
+    uint32_t src_mode  = (fcf >> 14) & 0x03;
+    uint32_t pan_comp  = (fcf >> 6)  & 0x01;
+
+    /* 2. Parse Destination Address Field (PAN ID + Address) */
+    if (dst_mode) {
+        /* Map Mode to length: Mode 2 (Short) -> 2 bytes, Mode 3 (Ext) -> 8 bytes.
+         * Using a ternary here allows compilers to use CMOV (conditional move)
+         * instructions to avoid pipeline stalls. */
+        uint32_t dst_addr_len = (dst_mode == 3) ? 8 : 2;
+
+        /* Destination PAN ID always follows Sequence Number at offset 3 */
+        *a_dest_panid = pr + 3;
+
+        /* Assign address pointers based on mode. Dest Addr starts at offset 5. */
+        if (dst_mode == 2) {
+            *a_dest_sa = pr + 5;
+        } else {
+            *a_dest_xa = pr + 5;
+        }
+
+        /* Update offset: 3 (FCF+Seq) + 2 (PAN) + AddrLength */
+        offset = 5 + dst_addr_len;
+    }
+
+    /* 3. Source PAN ID Compression Logic (Standard 2003/2006/2015 common subset).
+     * If compression bit is 0, a 2-byte Source PAN ID exists before the Source Addr. */
+    if (!pan_comp) {
+        offset += 2;
+    }
+
+    /* 4. Parse Source Address Field */
+    if (src_mode == 2) {
+        /* Source Short Address (2 bytes) */
+        *a_src_sa = pr + offset;
+    } else if (src_mode == 3) {
+        /* Source Extended Address (8 bytes) */
+        *a_src_xa = pr + offset;
+    }
+
+    return offset;
+}
+
+/**
+ * lmac154_parse_mhr_2015 - Strict MHR parser based on 802.15.4-2015 Table 7-2
+ * @pr: Pointer to frame start (MUST be 32-bit aligned)
+ * ... (output pointers)
+ *
+ * Returns the total length of the MHR in bytes.
+ */
+static inline uint32_t lmac154_parse_mhr_2015(uint8_t *pr,
+                       uint8_t **a_dest_panid, uint8_t **a_dest_sa,
+                       uint8_t **a_dest_xa, uint8_t **a_src_panid,
+                       uint8_t **a_src_sa, uint8_t **a_src_xa)
+{
+    uint32_t head = *(const uint32_t *)pr;
+    uint16_t fcf = (uint16_t)(head & 0xffff);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+    uint32_t offset;
+    bool has_dst_pan = false;
+    bool has_src_pan = false;
+
+    /* 1. Sequence Number Suppression (Version 2 feature) */
+    offset = (fcf & (1 << 8)) ? 2 : 3;
+
+    /* 2. Strict Table 7-2 Logic Implementation */
+    if (dst_mode == 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 1);
+    } else if (dst_mode > 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 0);
+    } else if (dst_mode == 0 && src_mode > 0) {
+        has_src_pan = (pan_comp == 0);
+    } else if (dst_mode == 3 && src_mode == 3) {
+        /* Extended <-> Extended: Row 7 & 8 */
+        has_dst_pan = (pan_comp == 0);
+        has_src_pan = false;
+    } else {
+        /* Mixed or Short <-> Short: Row 9-14 */
+        if (pan_comp == 0) {
+            has_dst_pan = true;
+            has_src_pan = true;
+        } else {
+            has_dst_pan = true;
+            has_src_pan = false;
+        }
+    }
+
+    /* 3. Extract Destination Fields */
+    if (has_dst_pan) {
+        *a_dest_panid = pr + offset;
+        offset += 2;
+    }
+
+    if (dst_mode == 2) {
+        *a_dest_sa = pr + offset;
+        offset += 2;
+    } else if (dst_mode == 3) {
+        *a_dest_xa = pr + offset;
+        offset += 8;
+    }
+
+    /* 4. Extract Source Fields */
+    if (has_src_pan) {
+        *a_src_panid = pr + offset;
+        offset += 2;
+    }
+
+    if (src_mode == 2) {
+        *a_src_sa = pr + offset;
+        offset += 2;
+    } else if (src_mode == 3) {
+        *a_src_xa = pr + offset;
+        offset += 8;
+    }
+
+    return offset;
+}
+
+/**
+ * lmac154_get_mhr_len - MHR length for 802.15.4-2003/2006
+ * @pkt: Pointer to frame start
+ */
+static inline uint32_t lmac154_get_mhr_len(const uint8_t *pkt)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+    uint32_t pos = 3; /* FCF(2) + Seq(1), Legacy always has Seq */
+
+    /* Destination Field */
+    if (dst_mode) {
+        pos += 2; /* Destination PAN ID always present if DstMode > 0 */
+        pos += (dst_mode == 3 ? 8 : 2);
+    }
+
+    /* Source Field */
+    if (src_mode) {
+        /* In Legacy: Source PAN is omitted ONLY IF:
+         * Both addresses are present AND PanComp is set to 1.
+         */
+        if (!dst_mode || !pan_comp) {
+            pos += 2; /* Source PAN ID present */
+        }
+        pos += (src_mode == 3 ? 8 : 2);
+    }
+
+    return pos;
+}
+
+/**
+ * lmac154_get_mhr_len_2015 - MHR length for 802.15.4-2015 (Strict Table 7-2)
+ * @pkt: Pointer to frame start
+ */
+static inline uint32_t lmac154_get_mhr_len_2015(const uint8_t *pkt)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+
+    /* Sequence Number Suppression: Bit 8 */
+    uint32_t pos = (fcf & (1 << 8)) ? 2 : 3;
+
+    bool has_dst_pan = false;
+    bool has_src_pan = false;
+
+    /* Strict Mapping of Table 7-2 */
+    if (dst_mode == 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 1); /* Row 1 & 2 */
+    } else if (dst_mode > 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 0); /* Row 3 & 4 */
+    } else if (dst_mode == 0 && src_mode > 0) {
+        has_src_pan = (pan_comp == 0); /* Row 5 & 6 */
+    } else if (dst_mode == 3 && src_mode == 3) {
+        has_dst_pan = (pan_comp == 0); /* Row 7 & 8: Extended-to-Extended */
+    } else {
+        /* Mixed or Short-to-Short: Rows 9-14 */
+        if (pan_comp == 0) {
+            has_dst_pan = true;  /* Row 9, 10, 11 */
+            has_src_pan = true;
+        } else {
+            has_dst_pan = true;  /* Row 12, 13, 14 */
+            has_src_pan = false;
+        }
+    }
+
+    if (has_dst_pan) pos += 2;
+    if (dst_mode > 0) pos += (dst_mode == 3 ? 8 : 2);
+    if (has_src_pan) pos += 2;
+    if (src_mode > 0) pos += (src_mode == 3 ? 8 : 2);
+
+    return pos;
+}
+
+/**
+ * @brief  Calculates the Auxiliary Security Header length.
+ * @param  pkt: Pointer to the start of the frame.
+ * @param  mhr_len: The offset where Aux Header starts (output of lmac154_get_mhr_len).
+ * @return Length of the Security Header (5, 6, 10, or 14 bytes).
+ */
+static inline uint32_t lmac154_get_aux_sec_len(uint8_t *pkt, uint32_t mhr_len)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint8_t sec_ctrl;
+    uint32_t key_id_mode;
+    uint32_t extra;
+
+    /* If Security Enabled bit (Bit 3) is not set, length is 0 */
+    if (!(fcf & 0x0008)) {
+        return 0;
+    }
+
+    /* Read Security Control byte at the calculated offset */
+    sec_ctrl = pkt[mhr_len];
+    key_id_mode = (sec_ctrl >> 3) & 0x03;
+
+    /* Fast lookup using a packed 32-bit constant (Register-based LUT):
+     * modes 0->0, 1->1, 2->5, 3->9 bytes extra for KeyID.
+     */
+    extra = (0x09050100 >> (key_id_mode << 3)) & 0xFF;
+
+    /* Base Security Header is 5 bytes: Security Control(1) + Frame Counter(4) */
+    return 5 + extra;
+}
+
+/**
+ * lmac154_parse_aux_hdr - Safely map and return the next position
+ * @pkt: Pointer to frame start (32-bit aligned)
+ * @mhr_len: Offset to security header
+ * @p_aux_hdr: Output pointer
+ *
+ * Return: Next position pointer.
+ */
+static inline uint32_t lmac154_parse_aux_hdr(uint8_t *pkt, uint32_t mhr_len,
+                        lmac154_aux_hdr_t **p_aux_hdr)
+{
+    uint32_t len;
+    uint8_t *pos = pkt + mhr_len;
+
+    len = lmac154_get_aux_sec_len(pkt, mhr_len);
+    if (len == 0) {
+        if (p_aux_hdr)
+            *p_aux_hdr = NULL;
+        return 0;
+    }
+
+    if (p_aux_hdr)
+        *p_aux_hdr = (lmac154_aux_hdr_t *)pos;
+
+    return len;
+}
+
+/**
+ * lmac154_traverse_ie - IE section traversal
+ * @ie_start: Pointer to the start of IE section
+ * @ie_len: Maximum length to search (buffer limit)
+ * @target_id: Target IE ID to locate; @found_ie is set on first match
+ * @found_ie: Output pointer to the matched IE header (NULL if not found)
+ *
+ * Return: Total bytes from ie_start to the end of the Termination IE.
+ * Always traverses the full IE section regardless of target match.
+ * Returns 0 if a structural error (truncation) is detected.
+ */
+static inline uint32_t lmac154_traverse_ie(uint8_t *ie_start, uint32_t ie_len,
+                       uint8_t target_id, lmac154_ie_hdr_t **found_ie)
+{
+    uint8_t *cur = ie_start;
+    uint8_t *limit = ie_start + ie_len;
+
+    if (found_ie)
+        *found_ie = NULL;
+
+    /* Pre-check: Minimal Header IE is 2 bytes */
+    while (cur + 2 <= limit) {
+        /* RISC-V Safe: Byte-by-byte 16-bit header fetch
+         * Bits: [0:6] Length, [7:14] ID, [15] Type
+         */
+        uint32_t hdr = (uint32_t)(cur[0] | (cur[1] << 8));
+        uint32_t len = hdr & 0x7F;
+        uint32_t id  = (hdr >> 7) & 0xFF;
+        uint32_t total_sz = len + 2;
+
+        /* 1. Fast Termination Check: 0x7E/0x7F both match (id & 0xFE) == 0x7E */
+        if ((id & 0xFE) == 0x7E) {
+            cur += 2;
+            break;
+        }
+
+        /* 2. Boundary Validation */
+        if (cur + total_sz > limit)
+            return 0;
+
+        /* 3. Target Matching - record first occurrence, continue traversal */
+        if (id == target_id) {
+            if (found_ie && !*found_ie)
+                *found_ie = (lmac154_ie_hdr_t *)cur;
+        }
+
+        /* 4. Advance pointer */
+        cur += total_sz;
+    }
+
+    /* Return total length of all traversed IEs (including termination) */
+    return (uint32_t)(cur - ie_start);
+}
+
+/**
+ * @brief  Generate CSL IE and return the computed phase value.
+ * @note   CslPhase = ceil((sample_time - tx_sfd_sym) % period / 10),
+ *         in 10-symbol units per IEEE 802.15.4-2015.
+ * @param  csl_period     CSL period in 10-symbol units.
+ * @param  csl_sample_time  CSL sample time in symbol count.
+ * @param  csl_ie         Output CSL IE buffer.
+ * @param  tx_sfd_sym     Estimated TX SFD time in symbol count.
+ * @return CSL phase value written to the IE.
+ */
+static inline uint16_t lmac154_gen_csl_ie(uint16_t csl_period, uint32_t csl_sample_time,
+                                           lmac154_ie_csl_t *csl_ie, uint32_t tx_sfd_sym)
+{
+    uint32_t period_sym = (uint32_t)csl_period * 10;
+    uint32_t delta_sym  = (csl_sample_time - tx_sfd_sym) % period_sym;
+    uint16_t csl_phase  = (uint16_t)((delta_sym + 9) / 10);
+
+    csl_ie->bf.hdr.length     = 4;
+    csl_ie->bf.hdr.element_id = LMAC154_IE_CSL_ID;
+    csl_ie->bf.hdr.type       = 0;
+    csl_ie->bf.phase          = csl_phase;
+    csl_ie->bf.period         = csl_period;
+
+    return csl_phase;
+}
+
+#endif /* __LMAC154_FRAME_H__ */

--- a/include/bouffalolab/bl70x/lmac154/lmac154_lp.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154_lp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_PDS_H__
+#define __LMAC154_PDS_H__
+
+/****************************************************************************//**
+ * @brief  Store registers to backup memory
+ *
+ * @param  retentionMem: retention memory to hold registers configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepStoreRegs(uint32_t *retentionMem);
+
+/****************************************************************************//**
+ * @brief  Restore registers from backup memory
+ *
+ * @param  retentionMem: retention memory hold register configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepRestoreRegs(uint32_t *retentionMem);
+
+#endif

--- a/include/bouffalolab/bl70x/lmac154/lmac154_lp.h
+++ b/include/bouffalolab/bl70x/lmac154/lmac154_lp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_PDS_H__
+#define __LMAC154_PDS_H__
+
+/****************************************************************************
+ * @brief  Store registers to backup memory
+ *
+ * @param  retentionMem: retention memory to hold registers configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepStoreRegs(uint32_t *retentionMem);
+
+/****************************************************************************
+ * @brief  Restore registers from backup memory
+ *
+ * @param  retentionMem: retention memory hold register configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepRestoreRegs(uint32_t *retentionMem);
+
+#endif

--- a/include/bouffalolab/bl70xl/lmac154/lmac154.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154.h
@@ -1,0 +1,1622 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_H__
+#define __LMAC154_H__
+
+#define VERSION_LMAC154_MAJOR 1
+#define VERSION_LMAC154_MINOR 6
+#define VERSION_LMAC154_PATCH 18
+
+typedef void (*lmac154_isr_t)(void);
+
+typedef enum {
+    LMAC154_CHANNEL_NONE = -1,
+    LMAC154_CHANNEL_11 = 0,
+    LMAC154_CHANNEL_12,
+    LMAC154_CHANNEL_13,
+    LMAC154_CHANNEL_14,
+    LMAC154_CHANNEL_15,
+    LMAC154_CHANNEL_16,
+    LMAC154_CHANNEL_17,
+    LMAC154_CHANNEL_18,
+    LMAC154_CHANNEL_19,
+    LMAC154_CHANNEL_20,
+    LMAC154_CHANNEL_21,
+    LMAC154_CHANNEL_22,
+    LMAC154_CHANNEL_23,
+    LMAC154_CHANNEL_24,
+    LMAC154_CHANNEL_25,
+    LMAC154_CHANNEL_26,
+}lmac154_channel_t;
+
+typedef enum {
+    LMAC154_TX_POWER_0dBm  = 0,
+    LMAC154_TX_POWER_1dBm  = 1,
+    LMAC154_TX_POWER_2dBm  = 2,
+    LMAC154_TX_POWER_3dBm  = 3,
+    LMAC154_TX_POWER_4dBm  = 4,
+    LMAC154_TX_POWER_5dBm  = 5,
+    LMAC154_TX_POWER_6dBm  = 6,
+    LMAC154_TX_POWER_7dBm  = 7,
+    LMAC154_TX_POWER_8dBm  = 8,
+    LMAC154_TX_POWER_9dBm  = 9,
+    LMAC154_TX_POWER_10dBm = 10,
+    LMAC154_TX_POWER_11dBm = 11,
+    LMAC154_TX_POWER_12dBm = 12,
+    LMAC154_TX_POWER_13dBm = 13,
+    LMAC154_TX_POWER_14dBm = 14,
+}lmac154_tx_power_t;
+
+typedef enum {
+    LMAC154_DATA_RATE_250K = 0,
+    LMAC154_DATA_RATE_500K = 1,
+    LMAC154_DATA_RATE_1M   = 2,
+    LMAC154_DATA_RATE_2M   = 3,
+}lmac154_data_rate_t;
+
+typedef enum {
+    LMAC154_CCA_MODE_ED        = 0,
+    LMAC154_CCA_MODE_CS        = 1,
+    LMAC154_CCA_MODE_ED_AND_CS = 2,
+    LMAC154_CCA_MODE_ED_OR_CS  = 3,
+}lmac154_cca_mode_t;
+
+typedef enum {
+    LMAC154_FRAME_TYPE_BEACON = 0x01,
+    LMAC154_FRAME_TYPE_DATA   = 0x02,
+    LMAC154_FRAME_TYPE_ACK    = 0x04,
+    LMAC154_FRAME_TYPE_CMD    = 0x08,
+    LMAC154_FRAME_TYPE_MPP    = 0x10,
+}lmac154_frame_type_t;
+
+typedef enum {
+    LMAC154_RF_PWR_OFF        = 0,
+    LMAC154_RF_STATE_RX       = 1,
+    LMAC154_RF_STATE_RX_DOING = 2,
+    LMAC154_RF_STATE_TX       = 3,
+    LMAC154_RF_STATE_IDLE     = 4,
+}lmac154_rf_state_t;
+
+typedef enum {
+    LMAC154_AES_MODE_ENCRYPT = 0,
+    LMAC154_AES_MODE_DECRYPT = 1,
+}lmac154_aes_mode_t;
+
+typedef enum {
+    LMAC154_AES_MIC_LEN_4  = 0,
+    LMAC154_AES_MIC_LEN_8  = 1,
+    LMAC154_AES_MIC_LEN_16 = 2,
+    LMAC154_AES_MIC_LEN_12 = 3,
+}lmac154_aes_mic_len_t;
+
+typedef enum {
+    LMAC154_AES_STATUS_SUCCESS         = 0,
+    LMAC154_AES_STATUS_INVALID_MODE    = -1,
+    LMAC154_AES_STATUS_INVALID_MIC_LEN = -2,
+    LMAC154_AES_STATUS_REENTER         = -3,
+    LMAC154_AES_STATUS_TIMEOUT         = -4,
+}lmac154_aes_status_t;
+
+typedef enum {
+    LMAC154_FPT_STATUS_SUCCESS          = 0,
+    LMAC154_FPT_STATUS_NO_RESOURCE      = -1,
+    LMAC154_FPT_STATUS_ADDR_NOT_FOUND   = -2,
+    LMAC154_FPT_STATUS_EMPTY            = -3,
+    LMAC154_FPT_STATUS_INVALID_PARAM    = -4,
+    LMAC154_FPT_STATUS_INVALID_OPT      = -5
+}lmac154_fpt_status_t;
+
+
+typedef enum {
+    LMAC154_TX_STATUS_TX_FINISHED = 0,
+    LMAC154_TX_STATUS_CSMA_FAILED = 1,
+    LMAC154_TX_STATUS_TX_ABORTED  = 2,
+    LMAC154_TX_STATUS_HW_ERROR    = 3,
+    LMAC154_TX_STATUS_DELAY_ERROR = 4,
+}lmac154_tx_status_t;
+
+typedef enum {
+    LMAC154_EVENT_TIME_RX_START = 0,
+    LMAC154_EVENT_TIME_RX_END   = 1,
+    LMAC154_EVENT_TIME_TX_END   = 4,
+}lmac154_eventTimeType_t;
+
+typedef enum {
+    LMAC154_RX_REJECT_CRC_ERR            = 0x00000001, // will reject packets that CRC check error
+    LMAC154_RX_REJECT_FRAME_TYPE_RVSD    = 0x00000002, // will reject packets that the value of frame type filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_FRAME_VER_RVSD     = 0x00000004, // will reject packets that the value of frame version filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_DST_ADDR_M_RVSD    = 0x00000008, // will reject packets that the value of dest address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_SRC_ADDR_M_RVSD    = 0x00000010, // will reject packets that the value of src address mode filed is reserved in 802.15.4 spec
+    LMAC154_RX_REJECT_DST_PANID_MISMATCH = 0x00000020, // will reject packets that the value of dest PANID does not match with local device
+    LMAC154_RX_REJECT_DST_ADDR_MISMATCH  = 0x00000040, // will reject packets that the value of dest address does not match with local device
+    LMAC154_RX_REJECT_SRC_PANID_MISMATCH = 0x00000080, // will reject packets that the value of src PANID does not match with local device
+
+    LMAC154_RX_REJECT_NONE               = 0x00000000, // will not reject all packets above
+    LMAC154_RX_REJECT_ALL                = 0x000000ff, // will reject all packets above
+}lmac154_rx_reject_policy_t;
+
+typedef enum {
+    LMAC154_RX_ACCEPT_CRC_ERR            = 0x00000001, // able to receive packets that CRC check error
+    LMAC154_RX_ACCEPT_FRAME_TYPE_RVSD    = 0x00000002, // able to receive packets that the value of frame type filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_FRAME_VER_RVSD     = 0x00000004, // able to receive packets that the value of frame version filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_DST_ADDR_M_RVSD    = 0x00000008, // able to receive packets that the value of dest address mode filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_SRC_ADDR_M_RVSD    = 0x00000010, // able to receive packets that the value of src address mode filed is reserved in 802.15.4 spec 
+    LMAC154_RX_ACCEPT_DST_PANID_MISMATCH = 0x00000020, // able to receive packets that the value of dest PANID does not match with local device
+    LMAC154_RX_ACCEPT_DST_ADDR_MISMATCH  = 0x00000040, // able to receive packets that the value of dest address does not match with local device
+    LMAC154_RX_ACCEPT_SRC_PANID_MISMATCH = 0x00000080, // able to receive packets that the value of src PANID does not match with local device
+
+    LMAC154_RX_ACCEPT_NONE               = 0x00000000, // not able to receive all packets above
+    LMAC154_RX_ACCEPT_ALL                = 0x000000ff, // able to receive all packets above 
+}lmac154_rx_accept_policy_t;
+
+typedef enum {
+    lmac154_addr_info_none               = 0x00000000,
+    lmac154_addr_info_panid              = 0x00000001,
+    lmac154_addr_info_short_addr         = 0x00000002,
+    lmac154_addr_info_ext_addr           = 0x00000004,
+    lmac154_addr_info_panid_short_addr   = lmac154_addr_info_panid | lmac154_addr_info_short_addr,
+    lmac154_addr_info_panid_ext_addr     = lmac154_addr_info_panid | lmac154_addr_info_ext_addr,
+} lmac154_addr_info_t;
+
+
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK       (7)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA       (1)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK        (2)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD        (3)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP        (5)
+
+#define LMAC154_FRAME_SECURITY_MASK                 (1 << 3)
+#define LMAC154_FRAME_FRAME_PENDING_MASK            (1 << 4)
+#define LMAC154_FRAME_ACK_REQUEST_MASK              (1 << 5)
+#define LMAC154_FRAME_PANID_COMPRESSION             (1 << 6)
+#define LMAC154_FRAME_SEQ_SUPRESSION_MASK           (1 << 8)
+#define LMAC154_FRAME_IE_MASK                       (1 << 9)
+#define LMAC154_FRAME_ADDR_DEST_NONE                (0 << 10)
+#define LMAC154_FRAME_ADDR_DEST_SHORT               (2 << 10)
+#define LMAC154_FRAME_ADDR_DEST_EXT                 (3 << 10)
+#define LMAC154_FRAME_ADDR_DEST_MASK                (3 << 10)
+#define LMAC154_FRAME_VERSION_MASK                  (3 << 12)
+#define LMAC154_FRAME_VERSION_2015                  (2 << 12)
+#define LMAC154_FRAME_ADDR_SRC_NONE                 (0 << 14)
+#define LMAC154_FRAME_ADDR_SRC_SHORT                (2 << 14)
+#define LMAC154_FRAME_ADDR_SRC_EXT                  (3 << 14)
+#define LMAC154_FRAME_ADDR_SRC_MASK                 (3 << 14)
+
+#define LMAC154_FRAME_MPP_LONG_FRAME_BIT            (1 << 3)
+#define LMAC154_FRAME_MPP_SECURITY_BIT              (1 << 9)
+#define LMAC154_FRAME_MPP_ACK_REQ                   (1 << 14)
+
+#define LMAC154_FRAME_CMD_DATA_REQUEST              (4)
+#define LMAC154_FRAME_IS_CMD(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD)
+#define LMAC154_FRAME_IS_DATA(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA)
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+
+#define LMAC154_FRAME_IS_ACK_REQ(x)                 (((x) & LMAC154_FRAME_ACK_REQUEST_MASK) == LMAC154_FRAME_ACK_REQUEST_MASK)
+#define LMAC154_FRAME_IS_PANID_COMPRESSED(x)        (((x) & LMAC154_FRAME_PANID_COMPRESSION) == LMAC154_FRAME_PANID_COMPRESSION)
+
+
+#define LMAC154_FRAME_IS_FRAME_2015(x)              (((x) & LMAC154_FRAME_VERSION_MASK) == LMAC154_FRAME_VERSION_2015)
+
+#define LMAC154_FRAME_IS_FRAME_PENDED(x)            ((x) & LMAC154_FRAME_FRAME_PENDING_MASK)
+#define LMAC154_FRAME_IS_NORMAL_SECURITY(x)         ((x & LMAC154_FRAME_SECURITY_MASK) == LMAC154_FRAME_SECURITY_MASK)
+
+#define LMAC154_FRAME_IS_MPP(x)                     ((x & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP)
+#define LMAC154_FRAME_IS_MPP_LONG_FRAME(x)          ((x & LMAC154_FRAME_MPP_LONG_FRAME_BIT) == LMAC154_FRAME_MPP_LONG_FRAME_BIT)
+#define LMAC154_FRAME_IS_MPP_SECURITY(x)            (LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_SECURITY_BIT) == LMAC154_FRAME_MPP_SECURITY_BIT)
+
+#define LMAC154_FRAME_IS_MPP_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP(x) && LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_ACK_REQ) == LMAC154_FRAME_MPP_ACK_REQ)
+#define LMAC154_FRAME_IS_ENH_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP_ACK_REQ(x) || (LMAC154_FRAME_IS_ACK_REQ(x) && LMAC154_FRAME_IS_FRAME_2015(x)))
+#define LMAC154_FRAME_IS_IMM_ACK_REQ(x)             (LMAC154_FRAME_IS_ACK_REQ(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+
+#define LMAC154_FRAME_IS_SECURITY_ENABLED(x)        (LMAC154_FRAME_IS_MPP(x) ?                                                          \
+                                                        (LMAC154_FRAME_IS_MPP_SECURITY(x) : LMAC154_FRAME_IS_NORMAL_SECURITY(x))
+
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+#define LMAC154_FRAME_IS_IMM_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_ENH_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_IE_EXIST(x)                (((x) & LMAC154_FRAME_IE_MASK) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+#define LMAC154_FRAME_GET_SRC_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_SRC_MASK)
+#define LMAC154_FRAME_GET_DST_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_DEST_MASK)
+
+
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_MASK          (3 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_0             (0 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_1             (1 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_2             (2 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_3             (3 << 3)
+
+#define LMAC154_LIFS                    40
+#define LMAC154_SIFS                    12
+#define LMAC154_AIFS                    LMAC154_SIFS
+#define LMAC154_SIFS_MAX_FRAME_SIZE     18
+#define LMAC154_TURNAROUND              12
+#define LMAC154_PKT_MAX_LEN             127
+#define LMAC154_PREAMBLE_LEN            8
+
+#define LMAC154_US_PER_SYMBOL_BITS      4
+#define LMAC154_US_PER_SYMBOL           (1 << LMAC154_US_PER_SYMBOL_BITS)
+#define LMAC154_US_PER_SYMBOL_MASK      (LMAC154_US_PER_SYMBOL - 1)
+
+/****************************************************************************//**
+ * @brief  Initialize the hardware module
+ *         Call this function first
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_init(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC 15.4 feature for 2015 version
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2015Feature(void);
+
+/****************************************************************************//**
+ * @brief  Disable MAC 15.4 feature for 2015 version
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2015Feature(void);
+
+/****************************************************************************//**
+ * @brief  Enable second stack for dual stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2ndStack(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable second stack for dual stack, which is disable by default
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2ndStack(void);
+
+
+/****************************************************************************//**
+ * @brief  Check whether the second stack is enabled
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+uint32_t lmac154_is2ndStackEnabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Get whether lmac154 is disabled
+ *
+ * @param  None
+ *
+ * @return 1 for disabled, 0 for enabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isDisabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Monitor the hardware state
+ *         Call this function periodically (1ms recommended) if needed
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_monitor(void);
+
+
+/****************************************************************************//**
+ * @brief  Get the lmac154 interrupt handler for interrupt registration of M154_IRQn
+ *
+ * @param  None
+ *
+ * @return The lmac154 interrupt handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptHandler(void);
+lmac154_isr_t lmac154_get2015InterruptHandler(void);
+
+/****************************************************************************//**
+ * @brief  Get the version number
+ *
+ * @param  None
+ *
+ * @return The library version number
+ *
+*******************************************************************************/
+uint32_t lmac154_getVersionNumber(void);
+
+/****************************************************************************//**
+ * @brief  Get the version number string
+ *
+ * @param  None
+ *
+ * @return The library version number string
+ *
+*******************************************************************************/
+char * lmac154_getVersionString(void);
+
+/****************************************************************************//**
+ * @brief  Enable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer accepts all frames received from the PHY layer
+ *         Able to receive frames without any IFS but rx sensitivity may be degraded if enhanced_mode = 1
+ *         The MPDU is unavailable in lmac154_rxDoneEvent if ignore_mpdu = 1
+ *
+ * @param  enhanced_mode: 0: standard mode, 1: enhanced mode
+ * @param  ignore_mpdu: 0: read mpdu from registers, 1: do not read mpdu from registers
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxPromiscuousMode(uint8_t enhanced_mode, uint8_t ignore_mpdu);
+
+
+/****************************************************************************//**
+ * @brief  Disable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer only accepts frames that pass the address filtering
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxPromiscuousMode(void);
+
+
+/****************************************************************************//**
+ * @brief  Get whether rx promiscuous mode is enabled
+ *
+ * @param  None
+ *
+ * @return 1 for enabled; 0 for disabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isRxPromiscuousModeEnabled(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRx(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRx(void);
+
+
+/****************************************************************************//**
+ * @brief  Set rx on/off state when idle state
+ *
+ * @param  isRxOnWhenIdle: true is rx on when idle; otherwhile is rx off when idle
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxStateWhenIdle(bool isRxOnWhenIdle);
+
+/****************************************************************************//**
+ * @brief  Get rx on/off state when idle state
+ *
+ * @param  None 
+ *
+ * @return true is rx on when idle; otherwhile is rx off when idle
+ *
+*******************************************************************************/
+bool lmac154_isRxStateWhenIdle(void);
+
+/****************************************************************************//**
+ * @brief  Set the number of maximum retransmission times (default 0)
+ *         Will perform retransmission in case ack is not received if num > 0
+ *         Will raise lmac154_ackEvent(ack_received = 0) after maximum retransmission times
+ *
+ * @param  num: number of maximum retransmission times
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRetry(uint32_t num);
+
+
+/****************************************************************************//**
+ * @brief  Trigger TX
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma: 0: without CSMA, 1: with CSMA
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_triggerTx(uint8_t *DataPtr, uint8_t length, uint8_t csma);
+
+
+/****************************************************************************//**
+ * @brief  Trigger TX with tx time specified
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma_cca: 0: without CSMA, 1: with CSMA/CCA
+ * @param  baseTimeUs: the base time us for delay tx trigger
+ * @param  delayUs: the delay time from baseTimeUs to tx trigger
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerTxDelay(uint8_t *DataPtr, uint32_t length, uint32_t csma_cca, 
+    uint64_t baseTimeUs, uint32_t delayUs);
+
+/****************************************************************************//**
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerTx or 
+ *         lmac154_triggerTxDelay without data specified.
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+uint32_t lmac154_postFillMPDU(uint8_t *DataPtr, uint32_t length);
+
+/****************************************************************************//**
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerTx or 
+ *         lmac154_triggerTxDelay without data specified.
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 1 is selected
+ *
+*******************************************************************************/
+uint32_t lmac154_isTriggerTimeSelected(void);
+
+/****************************************************************************//**
+ * @brief  Run tx continuous modulation (PRBS15 pattern)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCM(void);
+
+#if defined(BL702) || defined(BL702L)
+/****************************************************************************//**
+ * @brief  Run tx continuous wave (single tone)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCW(void);
+#endif
+
+
+/****************************************************************************//**
+ * @brief  Reset tx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetTx(void);
+
+/****************************************************************************//**
+ * @brief  Reset rx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetRx(void);
+
+/****************************************************************************//**
+ * @brief  Set the channel (default LMAC154_CHANNEL_11)
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setChannel(lmac154_channel_t ch_ind);
+
+
+/****************************************************************************//**
+ * @brief  Get the channel
+ *
+ * @param  None
+ *
+ * @return The channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+*******************************************************************************/
+lmac154_channel_t lmac154_getChannel(void);
+
+
+/****************************************************************************//**
+ * @brief  Get RSSI in dBm
+ *
+ * @param  None
+ *
+ * @return RSSI in dBm
+ *
+*******************************************************************************/
+int lmac154_getRSSI(void);
+
+
+/****************************************************************************//**
+ * @brief  Get LQI
+ *
+ * @param  None
+ *
+ * @return LQI
+ *
+*******************************************************************************/
+int lmac154_getLQI(void);
+
+
+/****************************************************************************//**
+ * @brief  Get SFD correlation
+ *
+ * @param  None
+ *
+ * @return SFD correlation
+ *
+*******************************************************************************/
+uint8_t lmac154_getSFDCorrelation(void);
+
+
+/****************************************************************************//**
+ * @brief  Get the frequency offset in Hz
+ *
+ * @param  None
+ *
+ * @return The frequency offset in Hz
+ *
+*******************************************************************************/
+int lmac154_getFrequencyOffset(void);
+
+/****************************************************************************//**
+ * @brief  Set country code for tx power adjustment
+ *
+ * @param  country_code: country code, for example: CN
+ *
+ * @return true, if country code is valid.
+ *
+*******************************************************************************/
+bool lmac154_setCountryCode(const char * country_code);
+
+/****************************************************************************//**
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPower(lmac154_tx_power_t power_dbm);
+
+/****************************************************************************//**
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @param country_code: country code, for example: CN
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPowerWithPowerLimit(lmac154_tx_power_t power_dbm, lmac154_channel_t ch_ind, const char *country_code);
+
+/****************************************************************************//**
+ * @brief  Get tx power
+ *
+ * @param  None
+ *
+ * @return tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+*******************************************************************************/
+lmac154_tx_power_t lmac154_getTxPower(void);
+
+
+/****************************************************************************//**
+ * @brief  Set tx data rate (default LMAC154_DATA_RATE_250K)
+ *         The maximum tx mpdu length is 127 bytes for 250kbps tx data rate, and 255 bytes for others
+ *
+ * @param  rate: LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxDataRate(lmac154_data_rate_t rate);
+
+
+/****************************************************************************//**
+ * @brief  Enable auto rx data rate (default disabled)
+ *         The maximum rx mpdu length is 127 bytes for 250kbps rx data rate, and 255 bytes for others
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAutoRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable auto rx data rate (default disabled)
+ *         The rx data rate is 250kbps, and the maximum rx mpdu length is 127 bytes
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAutoRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Get rx data rate
+ *
+ * @param  None
+ *
+ * @return LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+*******************************************************************************/
+lmac154_data_rate_t lmac154_getRxDataRate(void);
+
+
+/****************************************************************************//**
+ * @brief  Set CCA mode (default LMAC154_CCA_MODE_ED_AND_CS)
+ *
+ * @param  mode: LMAC154_CCA_MODE_ED, LMAC154_CCA_MODE_CS, LMAC154_CCA_MODE_ED_AND_CS, or LMAC154_CCA_MODE_ED_OR_CS
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCCAMode(lmac154_cca_mode_t mode);
+
+
+/****************************************************************************//**
+ * @brief  Set CCA ED threshold (default -71dBm)
+ *
+ * @param  threshold: ED threshold ranging from -122 to 5 in dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEDThreshold(int threshold);
+
+
+/****************************************************************************//**
+ * @brief  Get CCA ED threshold
+ *
+ * @param  None
+ *
+ * @return ED threshold
+ *
+*******************************************************************************/
+int lmac154_getEDThreshold(void);
+
+
+/****************************************************************************//**
+ * @brief  Run CCA
+ *
+ * @param  rssi: rssi output ranging from -122 to 5 in dBm
+ *
+ * @return CCA result: 0: channel idle, 1: channel busy
+ *
+*******************************************************************************/
+uint8_t lmac154_runCCA(int *rssi);
+
+
+/****************************************************************************//**
+ * @brief  Set PAN ID (default 0x4321)
+ *
+ * @param  pid: PAN ID
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setPanId(uint16_t pid);
+void lmac154_set2ndPanId(uint16_t pid);
+
+
+/****************************************************************************//**
+ * @brief  Get PAN ID
+ *
+ * @param  None
+ *
+ * @return PAN ID
+ *
+*******************************************************************************/
+uint16_t lmac154_getPanId(void);
+uint16_t lmac154_get2ndPanId(void);
+
+
+/****************************************************************************//**
+ * @brief  Set 16-bit short address (default 0x0000)
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setShortAddr(uint16_t sadr);
+void lmac154_set2ndShortAddr(uint16_t sadr);
+
+
+/****************************************************************************//**
+ * @brief  Get 16-bit short address
+ *
+ * @param  None 
+ *
+ * @return 16-bit short address
+ *
+*******************************************************************************/
+uint16_t lmac154_getShortAddr(void);
+uint16_t lmac154_get2ndShortAddr(void);
+
+
+/****************************************************************************//**
+ * @brief  Set 64-bit long address (default 0xACDE4800_00000002)
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setLongAddr(uint8_t *ladr);
+void lmac154_set2ndLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Get 64-bit long address
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getLongAddr(uint8_t *ladr);
+void lmac154_get2ndLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Enable frame type filtering (default disabled)
+ *         Will only receive specified frame types
+ *
+ * @param  frame_types: any combination of LMAC154_FRAME_TYPE_XXX (BEACON, DATA, ACK, or CMD), via bitwise OR ('|') operation
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableFrameTypeFiltering(uint8_t frame_types);
+
+
+/****************************************************************************//**
+ * @brief  Disable frame type filtering (default disabled)
+ *         Will receive all valid frame types (BEACON, DATA, ACK, or CMD)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableFrameTypeFiltering(void);
+
+
+/****************************************************************************//**
+ * @brief  Set rx reject policy
+ *
+ * @param policy : enum lmac154_rx_reject_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxRejectPolicy(lmac154_rx_reject_policy_t policy);
+
+
+/****************************************************************************//**
+ * @brief  Get rx reject policy
+ *
+ * @param None
+ *
+ * @return Rx reject policy
+ *
+*******************************************************************************/
+lmac154_rx_reject_policy_t lmac154_getRxRejectPolicy(void);
+
+
+/****************************************************************************//**
+ * @brief  set rx accept policy
+ *         
+ *
+ * @param policy : enum lmac154_rx_accept_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxAcceptPolicy(lmac154_rx_accept_policy_t policy);
+
+
+/****************************************************************************//**
+ * @brief  get rx accept policy
+ *         
+ *
+ * @param None
+ *
+ * @return lmac154_rx_accept_policy : enum lmac154_rx_accept_policy_t
+ *
+*******************************************************************************/
+lmac154_rx_accept_policy_t lmac154_getRxAcceptPolicy(void);
+
+
+/****************************************************************************//**
+ * @brief  Set external PA
+ *         Restriction: txpin % 5 != rxpin % 5
+ *
+ * @param  txpin: tx pin ranging from 0 to 31
+ * @param  rxpin: rx pin ranging from 0 to 31
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setExtPA(uint8_t txpin, uint8_t rxpin);
+
+
+/****************************************************************************//**
+ * @brief  Get RF state
+ *
+ * @param  None
+ *
+ * @return LMAC154_RF_STATE_RX, LMAC154_RF_STATE_RX_DOING, LMAC154_RF_STATE_TX, or LMAC154_RF_STATE_IDLE
+ *
+*******************************************************************************/
+lmac154_rf_state_t lmac154_getRFState(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable the coexistence of 802.15.4 and BLE wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableCoex(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableCoex(void);
+
+
+/****************************************************************************//**
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCoexPriority(bool is_rx_on_after_rx_abort_enable, uint32_t tx_priority, 
+    uint32_t rx_unicast_priority, uint32_t rx_sfd_priority, uint32_t rx_idle_priority);
+
+/****************************************************************************//**
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getCoexPriority(bool * is_rx_on_after_rx_abort_enable, uint32_t * tx_priority, 
+    uint32_t * rx_unicast_priority, uint32_t * rx_sfd_priority, uint32_t * rx_idle_priority);
+
+/****************************************************************************//**
+ * @brief  Enable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableTxAbortInt(void);
+
+/****************************************************************************//**
+ * @brief  Disable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableTxAbortInt(void);
+
+/****************************************************************************//**
+ * @brief  Enable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableHwAutoTxAck(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableHwAutoTxAck(void);
+
+/****************************************************************************//**
+ * @brief  Get whether hardware auto transmission of ack frame is enabled
+ *
+ * @param  None
+ *
+ * @return ture, enabled
+ *
+*******************************************************************************/
+bool lmac154_isHwAutoTxAckEnabled(void);
+
+/****************************************************************************//**
+ * @brief  Enable lmac154_ackEvent (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable lmac154_ackEvent (default enabled)
+ *         Will raise lmac154_rxDoneEvent instead when ack is received
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxSecMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxSecMHREvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Enable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableReqEnhAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Disable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableReqEnhAckEvent(void);
+
+/****************************************************************************//**
+ * @brief  Get the receiving or received mpdu length in bytes (crc included)
+ *
+ * @param  None
+ *
+ * @return The receiving or received mpdu length
+ *
+*******************************************************************************/
+uint8_t lmac154_getRxLength(void);
+
+
+/****************************************************************************//**
+ * @brief  Read rx data (crc not included)
+ *
+ * @param  buf: pointer to data buffer
+ * @param  offset: data offset ranging from 0 to 252 in bytes
+ * @param  len: data length ranging from 1 to 253-offset in bytes
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxData(uint8_t *buf, uint8_t offset, uint8_t len);
+
+
+/****************************************************************************//**
+ * @brief  Read rx crc
+ *
+ * @param  crc: byte array to carry rx crc
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxCrc(uint8_t crc[2]);
+
+
+/****************************************************************************//**
+ * @brief  Set the maximum wait time for ack frame (default 864us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setAckWaitTime(uint16_t time_us);
+
+/****************************************************************************//**
+ * @brief  Get the maximum wait time for imm-ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getAckWaitTime(void);
+
+/****************************************************************************//**
+ * @brief  Set the maximum wait time for enh-ack ack frame (default 1500us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEnhAckWaitTime(uint16_t time_us);
+
+/****************************************************************************//**
+ * @brief  Get the maximum wait time for enh-ack ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getEnhAckWaitTime(void);
+
+/****************************************************************************//**
+ * @brief  Set the maximum and minimum CSMA-CA backoff exponent
+ *
+ * @param  max_be: maximum BE ranging from 3 to 8, default 5
+ * @param  min_be: minimum BE ranging from 0 to max_be, default 3
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setBE(uint8_t max_be, uint8_t min_be);
+
+/****************************************************************************//**
+ * @brief  Set maximum CSMA backoff
+ *
+ * @param  maxBackoff: maximum CSMA backoff
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setMaxCsmaBackoff(uint8_t maxBackoff);
+
+/****************************************************************************//**
+ * @brief  Set tx-rx transition time
+ *
+ * @param  time: us
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRxTransTime(uint8_t timeInUs);
+
+/****************************************************************************//**
+ * @brief  Get event timestamps
+ *
+ * @param  type: event timestamp type
+ *
+ * @return timestamp
+ *
+*******************************************************************************/
+uint64_t lmac154_getEventTimeUs(lmac154_eventTimeType_t type);
+
+bool lmac154_fptSetMaxNum(uint32_t shortAddrNum, uint32_t longAddrNum);
+
+/****************************************************************************//**
+ * @brief  Run AES CCM
+ *
+ * @param  mode: LMAC154_AES_MODE_ENCRYPT or LMAC154_AES_MODE_DECRYPT
+ * @param  a_data: pointer to additional authentication data buffer
+ * @param  a_len: length of additional authentication data in bytes
+ * @param  nonce: pointer to 13-byte nonce buffer
+ * @param  key: pointer to 4-word key buffer
+ * @param  mic_len: LMAC154_MIC_LEN_4, LMAC154_MIC_LEN_8, LMAC154_MIC_LEN_12, or LMAC154_MIC_LEN_16
+ * @param  mic: pointer to mic buffer
+ * @param  input_data: pointer to input data buffer
+ * @param  output_data: pointer to output data buffer
+ * @param  len: length of input data in bytes
+ *
+ * @return The error code
+ *
+*******************************************************************************/
+lmac154_aes_status_t lmac154_runAESCCM(lmac154_aes_mode_t mode, 
+                                       const uint8_t *a_data, 
+                                       uint8_t a_len, 
+                                       const uint8_t *nonce, 
+                                       const uint32_t *key, 
+                                       lmac154_aes_mic_len_t mic_len, 
+                                       uint32_t *mic, 
+                                       const uint32_t *input_data, 
+                                       uint32_t *output_data, 
+                                       uint8_t len);
+
+
+
+
+// hardware frame pending table (256 bytes)
+// shared by short addresses and long addresses (supports up to 128 short addresses or 32 long addresses or mixed)
+// used by hardware to set the frame pending bit of hw auto tx ack
+// if the address is not found in the table (e.g. not set or removed), the frame pending bit of hw auto tx ack is 1
+
+
+/****************************************************************************//**
+ * @brief  Add (or update) the key-value pair {sadr: pending} to (in) the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetShortAddrPending(uint16_t sadr, uint8_t pending);
+
+
+/****************************************************************************//**
+ * @brief  Add (or update) the key-value pair {ladr: pending} to (in) the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetLongAddrPending(uint8_t *ladr, uint8_t pending);
+
+
+/****************************************************************************//**
+ * @brief  Get the corresponding frame pending bit of the short address in the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetShortAddrPending(uint16_t sadr, uint8_t *pending);
+
+
+/****************************************************************************//**
+ * @brief  Get the corresponding frame pending bit of the long address in the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetLongAddrPending(uint8_t *ladr, uint8_t *pending);
+
+
+/****************************************************************************//**
+ * @brief  Remove the key-value pair {sadr: pending} from the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveShortAddr(uint16_t sadr);
+
+
+/****************************************************************************//**
+ * @brief  Remove the key-value pair {ladr: pending} from the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveLongAddr(uint8_t *ladr);
+
+
+/****************************************************************************//**
+ * @brief  Get short address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetShortAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************//**
+ * @brief  Get long address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetLongAddrList(void *list, uint8_t *entry_num);
+
+
+/****************************************************************************//**
+ * @brief  Set frame pending bit according to frame pending table, or force to set to 1
+ *
+ * @param  force: 0: set according to frame pending table (default), 1: force to set to 1
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptForcePending(uint8_t force);
+
+
+/****************************************************************************//**
+ * @brief  Clear the frame pending table
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptClear(void);
+
+
+/****************************************************************************//**
+ * @brief  Print the frame pending table using specified print function
+ *
+ * @param  print_func: user specified print function
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptDump(int print_func(const char *fmt, ...));
+
+
+// functions below are callback functions running in the interrupt context
+// should be implemented by user if needed
+
+
+/****************************************************************************//**
+ * @brief  Tx Done Event
+ *         Will be raised after calling lmac154_triggerTx
+ *
+ * @param  tx_status: LMAC154_TX_STATUS_XXX (TX_FINISHED, CSMA_FAILED, TX_ABORTED, or HW_ERROR)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_txDoneEvent(lmac154_tx_status_t tx_status);
+
+
+/****************************************************************************//**
+ * @brief  Ack Event
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  frame_pending: frame pending bit in ack frame
+ * @param  seq_num: sequence number in ack frame
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackEvent(uint8_t ack_received, uint8_t frame_pending, uint8_t seq_num);
+
+
+/****************************************************************************//**
+ * @brief  Ack Event with ack frame
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  rx_buf: pointer to the ack frame buffer
+ * @param  len: ACK frame length
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackFrameEvent(uint8_t ack_received, uint8_t *rx_buf, uint8_t len);
+
+
+/****************************************************************************//**
+ * @brief  Rx Done Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received mpdu length in bytes (crc included)
+ * @param  crc_fail: 0: crc pass, 1: crc fail
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxDoneEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t crc_fail);
+
+/****************************************************************************//**
+ * @brief  Rx Start Event
+ *         Will be raised when rx on MAC sublayer starts
+ *         lmac154_getRxLength is available because it is obtained from PHY layer
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxStartEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Hardware auto tx ack done event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_hwAutoTxAckDoneEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  A 2015 version unicast packet received and enh-ack is required to respond
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_reqEnhAckEvent(void);
+
+
+/****************************************************************************//**
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+
+/****************************************************************************//**
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxSecMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+#if CONFIG_LMAC154_LOG
+void lmac154_log_init(void);
+void lmac154_log(const char *format, ...);
+void lmac154_logs_output(void);
+#endif
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get memory address of destination PAN ID 
+ *         and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to the destination PAN ID in input frame, if present.
+ * @param  a_sa: pointer to destination short address in input frame, if present.
+ * @param  a_xa: pointer to destination extended address in input frame, 
+ *               if present.
+ * @return None
+*******************************************************************************/
+void lmac154_parseDestAddress(uint8_t * a_pkt, uint16_t ** a_panid, 
+                              uint16_t ** a_sa, uint8_t ** a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get memory address of source PANID 
+ *         and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to the source PAN ID in input frame, if present.
+ * @param  a_sa: pointer to source short address in input frame, if present.
+ * @param  a_xa: pointer to source extended address in input frame, if present.
+ * 
+ * @return None
+*******************************************************************************/
+void lmac154_parseSrcAddress(uint8_t * a_pkt, uint16_t **a_panid, 
+                             uint16_t ** a_sa, uint8_t ** a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get destination PAN ID and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to save destination PAN ID from input frame
+ * @param  a_sa: pointer to save destination short address from input frame, 
+ *              if present.
+ * @param  a_xa: pointer to save destination extended address from input frame, 
+ *              if present.
+ * 
+ * @return lmac154_addr_info_t to indicate information of source address
+*******************************************************************************/
+lmac154_addr_info_t lmac154_getDestAddress(uint8_t * a_pkt, uint16_t * a_panid, 
+                                           uint16_t * a_sa, uint8_t * a_xa);
+
+/****************************************************************************//**
+ * @brief  Parse IEEE 802.15.4 frame to get source PAN ID and address
+ *
+ * @param  a_pkt: pointer to IEEE 802.15.4 frame
+ * @param  a_panid: pointer to save source PAN ID from input frame
+ * @param  a_sa: pointer to save source short address from input frame, 
+ *              if present.
+ * @param  a_xa: pointer to save source extended address from input frame, 
+ *              if present.
+ * 
+ * @return lmac154_addr_info_t to indicate information of source address
+*******************************************************************************/
+lmac154_addr_info_t lmac154_getSrcAddress(uint8_t * a_pkt, uint16_t * a_panid, 
+                                          uint16_t * a_sa, uint8_t * a_xa);
+
+#endif

--- a/include/bouffalolab/bl70xl/lmac154/lmac154.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154.h
@@ -1,0 +1,1685 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_H__
+#define __LMAC154_H__
+
+#define VERSION_LMAC154_MAJOR 1
+#define VERSION_LMAC154_MINOR 7
+#define VERSION_LMAC154_PATCH 7
+
+#ifndef CONFIG_LMAC154_DBG
+#define CONFIG_LMAC154_DBG 0
+#endif
+
+#define M154_RD_WORD(addr)                          (*((volatile uint32_t *)(uintptr_t)(addr)))
+#define M154_WR_WORD(addr, val)                     ((*(volatile uint32_t *)(uintptr_t)(addr)) = (val))
+#define M154_RD_REG(addr, regname)                  M154_RD_WORD(addr + regname##_OFFSET)
+#define M154_WR_REG(addr, regname, val)             M154_WR_WORD(addr + regname##_OFFSET, val)
+
+#define M154_SET_REG_BIT(val, bitname)              ((val) | (1U << bitname##_POS))
+#define M154_CLR_REG_BIT(val, bitname)              ((val)&bitname##_UMSK)
+#define M154_GET_REG_BITS_VAL(val, bitname)         (((val)&bitname##_MSK) >> bitname##_POS)
+#define M154_SET_REG_BITS_VAL(val, bitname, bitval) (((val)&bitname##_UMSK) | ((uint32_t)(bitval) << bitname##_POS))
+#define M154_IS_REG_BIT_SET(val, bitname)           (((val) & (1U << (bitname##_POS))) != 0)
+
+typedef void (*lmac154_isr_t)(void);
+
+typedef enum {
+    LMAC154_CHANNEL_NONE = -1,
+    LMAC154_CHANNEL_11 = 0,
+    LMAC154_CHANNEL_12,
+    LMAC154_CHANNEL_13,
+    LMAC154_CHANNEL_14,
+    LMAC154_CHANNEL_15,
+    LMAC154_CHANNEL_16,
+    LMAC154_CHANNEL_17,
+    LMAC154_CHANNEL_18,
+    LMAC154_CHANNEL_19,
+    LMAC154_CHANNEL_20,
+    LMAC154_CHANNEL_21,
+    LMAC154_CHANNEL_22,
+    LMAC154_CHANNEL_23,
+    LMAC154_CHANNEL_24,
+    LMAC154_CHANNEL_25,
+    LMAC154_CHANNEL_26,
+}lmac154_channel_t;
+
+typedef enum {
+    LMAC154_TX_POWER_0dBm  = 0,
+    LMAC154_TX_POWER_1dBm  = 1,
+    LMAC154_TX_POWER_2dBm  = 2,
+    LMAC154_TX_POWER_3dBm  = 3,
+    LMAC154_TX_POWER_4dBm  = 4,
+    LMAC154_TX_POWER_5dBm  = 5,
+    LMAC154_TX_POWER_6dBm  = 6,
+    LMAC154_TX_POWER_7dBm  = 7,
+    LMAC154_TX_POWER_8dBm  = 8,
+    LMAC154_TX_POWER_9dBm  = 9,
+    LMAC154_TX_POWER_10dBm = 10,
+    LMAC154_TX_POWER_11dBm = 11,
+    LMAC154_TX_POWER_12dBm = 12,
+    LMAC154_TX_POWER_13dBm = 13,
+    LMAC154_TX_POWER_14dBm = 14,
+}lmac154_tx_power_t;
+
+typedef enum {
+    LMAC154_DATA_RATE_250K = 0,
+    LMAC154_DATA_RATE_500K = 1,
+    LMAC154_DATA_RATE_1M   = 2,
+    LMAC154_DATA_RATE_2M   = 3,
+}lmac154_data_rate_t;
+
+typedef enum {
+    LMAC154_CCA_MODE_ED        = 0,
+    LMAC154_CCA_MODE_CS        = 1,
+    LMAC154_CCA_MODE_ED_AND_CS = 2,
+    LMAC154_CCA_MODE_ED_OR_CS  = 3,
+}lmac154_cca_mode_t;
+
+typedef enum {
+    LMAC154_FRAME_TYPE_BEACON = 0x01,
+    LMAC154_FRAME_TYPE_DATA   = 0x02,
+    LMAC154_FRAME_TYPE_ACK    = 0x04,
+    LMAC154_FRAME_TYPE_CMD    = 0x08,
+    LMAC154_FRAME_TYPE_MPP    = 0x10,
+}lmac154_frame_type_t;
+
+typedef enum {
+    LMAC154_RF_STATE_RX_TRIG        = 1,
+    LMAC154_RF_STATE_RX             = 2,
+    LMAC154_RF_STATE_RX_DOING       = 3,
+    LMAC154_RF_STATE_ACK_DOING      = 4,
+    LMAC154_RF_STATE_TX             = 5,
+    LMAC154_RF_STATE_CSMA           = 6,
+    LMAC154_RF_STATE_IDLE           = 7,
+}lmac154_rf_state_t;
+
+typedef enum {
+    LMAC154_AES_MODE_ENCRYPT = 0,
+    LMAC154_AES_MODE_DECRYPT = 1,
+}lmac154_aes_mode_t;
+
+typedef enum {
+    LMAC154_AES_MIC_LEN_4  = 0,
+    LMAC154_AES_MIC_LEN_8  = 1,
+    LMAC154_AES_MIC_LEN_16 = 2,
+    LMAC154_AES_MIC_LEN_12 = 3,
+}lmac154_aes_mic_len_t;
+
+typedef enum {
+    LMAC154_AES_STATUS_SUCCESS         = 0,
+    LMAC154_AES_STATUS_INVALID_MODE    = -1,
+    LMAC154_AES_STATUS_INVALID_MIC_LEN = -2,
+    LMAC154_AES_STATUS_REENTER         = -3,
+    LMAC154_AES_STATUS_TIMEOUT         = -4,
+}lmac154_aes_status_t;
+
+typedef enum {
+    LMAC154_FPT_STATUS_SUCCESS          = 0,
+    LMAC154_FPT_STATUS_NO_RESOURCE      = -1,
+    LMAC154_FPT_STATUS_ADDR_NOT_FOUND   = -2,
+    LMAC154_FPT_STATUS_EMPTY            = -3,
+    LMAC154_FPT_STATUS_INVALID_PARAM    = -4,
+    LMAC154_FPT_STATUS_INVALID_OPT      = -5
+}lmac154_fpt_status_t;
+
+typedef enum {
+    LMAC154_TX_STATUS_TX_FINISHED = 0,
+    LMAC154_TX_STATUS_ACKED       = 1,
+    LMAC154_TX_STATUS_CSMA_FAILED = 2,
+    LMAC154_TX_STATUS_TX_ABORTED  = 3,
+    LMAC154_TX_STATUS_HW_ERROR    = 4,
+    LMAC154_TX_STATUS_DELAY_ERROR = 5,
+    LMAC154_TX_STATUS_NO_ACK      = 6,
+    LMAC154_TX_STATUS_CCA_FAILED  = 7,
+    LMAC154_TX_STATUS_MAX         = 8,
+}lmac154_tx_status_t;
+
+typedef enum {
+    LMAC154_RX_REJECT_CRC_ERR            = 0x00000001, /* will reject packets that CRC check error */
+    LMAC154_RX_REJECT_FRAME_TYPE_RVSD    = 0x00000002, /* will reject packets that the value of frame type filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_FRAME_VER_RVSD     = 0x00000004, /* will reject packets that the value of frame version filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_DST_ADDR_M_RVSD    = 0x00000008, /* will reject packets that the value of dest address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_SRC_ADDR_M_RVSD    = 0x00000010, /* will reject packets that the value of src address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_REJECT_DST_PANID_MISMATCH = 0x00000020, /* will reject packets that the value of dest PANID does not match with local device */
+    LMAC154_RX_REJECT_DST_ADDR_MISMATCH  = 0x00000040, /* will reject packets that the value of dest address does not match with local device */
+    LMAC154_RX_REJECT_SRC_PANID_MISMATCH = 0x00000080, /* will reject packets that the value of src PANID does not match with local device */
+
+    LMAC154_RX_REJECT_NONE               = 0x00000000, /* will not reject all packets above */
+    LMAC154_RX_REJECT_ALL                = 0x000000ff, /* will reject all packets above */
+}lmac154_rx_reject_policy_t;
+
+typedef enum {
+    LMAC154_RX_ACCEPT_CRC_ERR            = 0x00000001, /* able to receive packets that CRC check error */
+    LMAC154_RX_ACCEPT_FRAME_TYPE_RVSD    = 0x00000002, /* able to receive packets that the value of frame type filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_FRAME_VER_RVSD     = 0x00000004, /* able to receive packets that the value of frame version filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_DST_ADDR_M_RVSD    = 0x00000008, /* able to receive packets that the value of dest address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_SRC_ADDR_M_RVSD    = 0x00000010, /* able to receive packets that the value of src address mode filed is reserved in 802.15.4 spec */
+    LMAC154_RX_ACCEPT_DST_PANID_MISMATCH = 0x00000020, /* able to receive packets that the value of dest PANID does not match with local device */
+    LMAC154_RX_ACCEPT_DST_ADDR_MISMATCH  = 0x00000040, /* able to receive packets that the value of dest address does not match with local device */
+    LMAC154_RX_ACCEPT_SRC_PANID_MISMATCH = 0x00000080, /* able to receive packets that the value of src PANID does not match with local device */
+
+    LMAC154_RX_ACCEPT_NONE               = 0x00000000, /* not able to receive all packets above */
+    LMAC154_RX_ACCEPT_ALL                = 0x000000ff, /* able to receive all packets above */
+}lmac154_rx_accept_policy_t;
+
+typedef enum {
+    lmac154_addr_info_none               = 0x00000000,
+    lmac154_addr_info_panid              = 0x00000001,
+    lmac154_addr_info_short_addr         = 0x00000002,
+    lmac154_addr_info_ext_addr           = 0x00000004,
+    lmac154_addr_info_panid_short_addr   = lmac154_addr_info_panid | lmac154_addr_info_short_addr,
+    lmac154_addr_info_panid_ext_addr     = lmac154_addr_info_panid | lmac154_addr_info_ext_addr,
+} lmac154_addr_info_t;
+
+typedef void (*lmac154_txDoneCallback_t)(lmac154_tx_status_t, uint32_t *, uint32_t);
+
+/**
+ * @brief RX callback status codes
+ */
+typedef enum {
+    LMAC154_RX_STATUS_NONE          = 0,
+    LMAC154_RX_STATUS_RX_DONE       = 1,
+    LMAC154_RX_STATUS_ACK_SENT      = 2,
+    LMAC154_RX_STATUS_ACK_ERR       = 3,
+} lmac154_rx_status_t;
+
+typedef struct lmac154_receiveInfo lmac154_receiveInfo_t;
+
+typedef void (*lmac154_rxDoneCallback_t)(lmac154_rx_status_t, lmac154_receiveInfo_t *, uint32_t *);
+
+struct lmac154_receiveInfo {
+    uint32_t                        rx_length:8;
+    uint32_t                        nbr_idx:8;
+    uint32_t                        mac_hdr_size:8;
+    uint32_t                        is_tx_acking:1;
+    uint32_t                        is_enh_ack_requested:1;
+    uint32_t                        is_frame_pended:1;
+    uint32_t                        is_src_saddr:1;
+    uint32_t                        is_src_xaddr:1;
+    uint32_t                        stack_msk:2;
+    uint32_t                        unused:1;
+    uint16_t                        rx_error;
+    uint8_t                         enh_ack_time;
+    uint8_t                         dbg_en:1;
+    uint8_t                         dbg_rx_filter_en:1;
+    uint8_t                         dbg_ack_len:6;
+    int8_t                          dbg_ack_cost;
+    int8_t                          dbg_csl_drift_ack;
+    uint16_t                        dbg_csl_ack_phase;
+    uint32_t                        rx_done_symbol_cnt;
+    union {
+        uint16_t                    saddr;
+        uint32_t                    xaddr[2];
+        uint8_t                     addr[8];
+    } src_addr;
+    lmac154_rxDoneCallback_t        callback[2];
+};
+
+/****************************************************************************
+ * @brief  lmac154 stack index enumeration
+ *
+ ******************************************************************************/
+typedef enum {
+    LMAC154_STACK_1 = 0,  /**< First stack (default for single stack mode) */
+    LMAC154_STACK_2 = 1,  /**< Second stack (for dual stack mode) */
+} lmac154_stack_idx_t;
+
+typedef struct {
+    uint32_t *                      key;
+    uint8_t                         a_data_length;
+    uint8_t                         m_data_length;
+    struct {
+        uint32_t                    ext_addr[2];
+        uint32_t                    frame_cnt;
+        uint8_t                     security_level;
+    }                               nonce;
+    uint32_t *                      a_data;      /* Authentication data (header) */
+    uint32_t *                      m_data;      /* Message data */
+    uint32_t *                      c_data;      /* Encrypted output buffer */
+} lmac154_security_t;
+
+typedef struct {
+    uint32_t                        base_time;
+    uint32_t                        delay_time;
+} lmac154_tx_timing_t;
+
+typedef struct {
+    uint8_t                         csl_retry;
+    uint8_t                         csl_ie_offset;
+    uint16_t                        csl_period;
+    uint32_t                        csl_sample_time;
+    int8_t                          csl_tx_offset_sym_cnt;
+    int8_t                          dbg_csl_drift_tx;
+    uint16_t                        dbg_csl_tx_phase;
+} lmac154_csl_opt_t;
+
+typedef struct __lmac154_txParam_ext {
+    uint32_t *                      pkt;
+    uint32_t                        pkt_length:8;
+    uint32_t                        tx_channel:4;
+    uint32_t                        resume_channel:4;
+    uint32_t                        csma_ca_max_backoff:4;
+    uint32_t                        is_cca:1;
+    uint32_t                        is_ack_required:1;
+    uint32_t                        is_enh_ack_required:1;
+    uint32_t                        is_tx_doing:1;
+    uint32_t                        is_last_tx:1;
+    uint32_t                        is_base_param:1;
+    uint32_t                        is_tx_security:1;
+    uint32_t                        unused:5;
+    uint32_t                        ack_rx_done_symbol_cnt;
+    lmac154_txDoneCallback_t        tx_done_cb;
+    struct __lmac154_txParam_ext *  next;
+
+    lmac154_security_t              sec;
+    lmac154_tx_timing_t             tx_timing;
+    lmac154_csl_opt_t               csl_opt;
+#if CONFIG_LMAC154_DBG
+    uint32_t                        dbg_plat_entry_sym;
+#endif
+} lmac154_txParam_ext_t;
+
+typedef struct __lmac154_txParam {
+    uint32_t *                      pkt;
+    uint32_t                        pkt_length:8;
+    uint32_t                        tx_channel:4;
+    uint32_t                        resume_channel:4;
+    uint32_t                        csma_ca_max_backoff:4;
+    uint32_t                        is_cca:1;
+    uint32_t                        is_ack_required:1;
+    uint32_t                        is_enh_ack_required:1;
+    uint32_t                        is_tx_doing:1;
+    uint32_t                        is_last_tx:1;
+    uint32_t                        is_base_param:1;
+    uint32_t                        unused:6;
+    uint32_t                        ack_rx_done_symbol_cnt;
+    lmac154_txDoneCallback_t        tx_done_cb;
+    struct __lmac154_txParam_ext *  next;
+} lmac154_txParam_t;
+
+/* Frame control constants and macros have been moved to lmac154_frame.h */
+
+/****************************************************************************
+ * @brief  Initialize the hardware module
+ *         Call this function first
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_init(void);
+
+/****************************************************************************
+ * @brief  Enable MAC 15.4 2015 standard feature
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015(bool isEnable);
+
+/****************************************************************************
+ * @brief  Enable MAC 15.4 2015 standard feature with extra configuration
+ *
+ * @param  isEnable, enable to use 2015 standard feature
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setStd2015Extra(bool isEnable);
+
+/****************************************************************************
+ * @brief  Enable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable1stStack(void);
+
+/****************************************************************************
+ * @brief  Disable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable1stStack(void);
+
+/****************************************************************************
+ * @brief  Enable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable1stStack(void);
+
+/****************************************************************************
+ * @brief  Disable first stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable1stStack(void);
+
+/****************************************************************************
+ * @brief  Enable second stack for dual stack
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enable2ndStack(void);
+
+/****************************************************************************
+ * @brief  Disable second stack for dual stack, which is disable by default
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disable2ndStack(void);
+
+/****************************************************************************
+ * @brief  Check whether the second stack is enabled
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+uint32_t lmac154_is2ndStackEnabled(void);
+
+/****************************************************************************
+ * @brief  Get whether lmac154 is disabled
+ *
+ * @param  None
+ *
+ * @return 1 for disabled, 0 for enabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isDisabled(void);
+
+/****************************************************************************
+ * @brief  Monitor the hardware state
+ *
+ * @param  monitor_timeout, monitor timeout in ms
+ *
+ * @return monitor result
+ *
+*******************************************************************************/
+int lmac154_monitor(uint32_t monitor_timeout);
+
+/****************************************************************************
+ * @brief  Get the lmac154 interrupt handler for interrupt registration of M154_IRQn
+ *
+ * @param  None
+ *
+ * @return The lmac154 interrupt handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptHandler(void);
+
+/****************************************************************************
+ * @brief  Register rx done event callback for specific stack and get m154 irq handler
+ *
+ * @param  stack_idx, which stack to register (LMAC154_STACK_1 or LMAC154_STACK_2)
+ * @param  stack_rxDoneCallback, frame received callback function
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+bool lmac154_registerEventCallback(lmac154_stack_idx_t stack_idx,
+                                   lmac154_rxDoneCallback_t stack_rxDoneCallback);
+
+/****************************************************************************
+ * @brief  Register rx done event callback and get m154 irq handler
+ *
+ * @param  stack1_rxDoneCallback, frame received with destination panid on stack 1
+ *
+ * @param  stack2_rxDoneCallback, frame received with destination panid on stack 2
+ *
+ * @return The m154 irq handler
+ *
+*******************************************************************************/
+lmac154_isr_t lmac154_getInterruptCallback(void);
+
+/****************************************************************************
+ * @brief  Get the version number
+ *
+ * @param  None
+ *
+ * @return The library version number
+ *
+*******************************************************************************/
+uint32_t lmac154_getVersionNumber(void);
+
+/****************************************************************************
+ * @brief  Get the version number string
+ *
+ * @param  None
+ *
+ * @return The library version number string
+ *
+*******************************************************************************/
+char * lmac154_getVersionString(void);
+
+/****************************************************************************
+ * @brief  Enable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer accepts all frames received from the PHY layer
+ *         Able to receive frames without any IFS but rx sensitivity may be degraded if enhanced_mode = 1
+ *         The MPDU is unavailable in lmac154_rxDoneEvent if ignore_mpdu = 1
+ *
+ * @param  enhanced_mode: 0: standard mode, 1: enhanced mode
+ * @param  ignore_mpdu: 0: read mpdu from registers, 1: do not read mpdu from registers
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxPromiscuousMode(uint8_t enhanced_mode, uint8_t ignore_mpdu);
+
+/****************************************************************************
+ * @brief  Disable standard or enhanced rx promiscuous mode (default disabled)
+ *         The MAC sublayer only accepts frames that pass the address filtering
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxPromiscuousMode(void);
+
+/****************************************************************************
+ * @brief  Get whether rx promiscuous mode is enabled
+ *
+ * @param  None
+ *
+ * @return 1 for enabled; 0 for disabled
+ *
+*******************************************************************************/
+uint32_t lmac154_isRxPromiscuousModeEnabled(void);
+
+/****************************************************************************
+ * @brief  Enable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRx(void);
+
+/****************************************************************************
+ * @brief  try to force enable rx
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_forceEnableRX(void);
+
+/****************************************************************************
+ * @brief  Disable RX (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRx(void);
+
+/****************************************************************************
+ * @brief  Set rx on/off state when idle state
+ *
+ * @param  isRxOnWhenIdle: true is rx on when idle; otherwhile is rx off when idle
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxStateWhenIdle(bool isRxOnWhenIdle);
+
+/****************************************************************************
+ * @brief  Get rx on/off state when idle state
+ *
+ * @param  None
+ *
+ * @return true is rx on when idle; otherwhile is rx off when idle
+ *
+*******************************************************************************/
+bool lmac154_isRxStateWhenIdle(void);
+
+/****************************************************************************
+ * @brief  Set the number of maximum retransmission times (default 0)
+ *         Will perform retransmission in case ack is not received if num > 0
+ *         Will raise lmac154_ackEvent(ack_received = 0) after maximum retransmission times
+ *
+ * @param  num: number of maximum retransmission times
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRetry(uint32_t num);
+
+/****************************************************************************
+ * @brief  Trigger TX
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ * @param  csma: 0: without CSMA, 1: with CSMA
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_triggerTx(uint8_t *DataPtr, uint8_t length, uint8_t csma);
+
+/****************************************************************************
+ * @brief  Trigger TX with base parameter set (no CSL/extended options).
+ *         Wraps lmac154_triggerParamTxExt with is_base_param flag set.
+ *         Must be called within critical section.
+ *
+ * @param  txParam: pointer to lmac154_txParam_t
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTx(lmac154_txParam_t * txParam);
+
+/****************************************************************************
+ * @brief  Trigger TX with extended parameter set.
+ *         Performs CSMA-CA backoff (hardware or software), sets up the MPDU,
+ *         configures CSL IE if applicable, and triggers the radio transmit.
+ *         Must be called within critical section.
+ *
+ * @param  txParam: pointer to lmac154_txParam_ext_t
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_triggerParamTxExt(lmac154_txParam_ext_t * txParam);
+
+/****************************************************************************
+ * @brief  Encrypt packet using AES-CCM with parameters from lmac154_security_t
+ *
+ * Supports frames with or without payload (e.g., enhanced ACK with only header).
+ *
+ * @param  param: pointer to lmac154_security_t containing encryption parameters
+ *                - key: AES key pointer [required]
+ *                - nonce: nonce (ext_addr, frame_cnt, key_id) [required]
+ *                - security_level: security level (determines MIC length) [required]
+ *                - a_data: authentication data (header, plaintext) [required]
+ *                - m_data: message data (plaintext) [optional, can be NULL]
+ *                - c_data: output buffer for encrypted message + MIC [required]
+ *                - a_data_length: length of authentication data [required]
+ *                - m_data_length: length of message data (0 if no payload) [optional]
+ *
+ * @return Encrypted message length + MIC length on success (if m_data_length=0, returns MIC length only),
+ *         negative error code on failure
+ *
+ *******************************************************************************/
+int32_t lmac154_encryptPacket(lmac154_security_t * param);
+
+/****************************************************************************
+ * @brief  Write TX ack frame to mpdu buffer to send in lmac154_receivedEvent
+ *         with isEnhAckExpected true.
+ *
+ * @param  ack_frame: pointer to data buffer of ack frame
+ * @param  ack_frame_length: data length in bytes
+ *
+ * @return 0 is Success
+ *
+*******************************************************************************/
+int lmac154_writeTxAckFrame(uint8_t *ack_frame, int ack_frame_length);
+
+/****************************************************************************
+ * @brief  File MPDU data after tx trigger requested when lmac154_triggerParamTx
+ *         is called with time specified
+ *
+ * @param  DataPtr: pointer to data buffer
+ * @param  length: data length in bytes
+ *
+ * @return 1 is selected
+ *
+*******************************************************************************/
+uint32_t lmac154_isTriggerTimeSelected(void);
+
+/****************************************************************************
+ * @brief  Run tx continuous modulation (PRBS15 pattern)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCM(void);
+
+#if defined(BL702) || defined(BL702L)
+/****************************************************************************
+ * @brief  Run tx continuous wave (single tone)
+ *         Call lmac154_resetTx to stop
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_runTxCW(void);
+#endif
+
+/****************************************************************************
+ * @brief  Reset tx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetTx(void);
+
+/****************************************************************************
+ * @brief  Reset rx state machine
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_resetRx(void);
+
+/****************************************************************************
+ * @brief  Set the channel (default LMAC154_CHANNEL_11)
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setChannel(lmac154_channel_t ch_ind);
+
+/****************************************************************************
+ * @brief  Get the channel
+ *
+ * @param  None
+ *
+ * @return The channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+*******************************************************************************/
+lmac154_channel_t lmac154_getChannel(void);
+
+/****************************************************************************
+ * @brief  Get RSSI in dBm
+ *
+ * @param  None
+ *
+ * @return RSSI in dBm
+ *
+*******************************************************************************/
+int lmac154_getRSSI(void);
+
+/****************************************************************************
+ * @brief  Get LQI
+ *
+ * @param  None
+ *
+ * @return LQI
+ *
+*******************************************************************************/
+int lmac154_getLQI(void);
+
+/****************************************************************************
+ * @brief  Get SFD correlation
+ *
+ * @param  None
+ *
+ * @return SFD correlation
+ *
+*******************************************************************************/
+uint8_t lmac154_getSFDCorrelation(void);
+
+/****************************************************************************
+ * @brief  Get the frequency offset in Hz
+ *
+ * @param  None
+ *
+ * @return The frequency offset in Hz
+ *
+*******************************************************************************/
+int lmac154_getFrequencyOffset(void);
+
+/****************************************************************************
+ * @brief  Set country code for tx power adjustment
+ *
+ * @param  country_code: country code, for example: CN
+ *
+ * @return true, if country code is valid.
+ *
+*******************************************************************************/
+bool lmac154_setCountryCode(const char * country_code);
+
+/****************************************************************************
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPower(lmac154_tx_power_t power_dbm);
+
+/****************************************************************************
+ * @brief  Set tx power (no default value)
+ *
+ * @param  power_dbm: tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+ * @param  ch_ind: channel index ranging from LMAC154_CHANNEL_11 to LMAC154_CHANNEL_26
+ *
+ * @param country_code: country code, for example: CN
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxPowerWithPowerLimit(lmac154_tx_power_t power_dbm, lmac154_channel_t ch_ind, const char *country_code);
+
+/****************************************************************************
+ * @brief  Get tx power
+ *
+ * @param  None
+ *
+ * @return tx power ranging from LMAC154_TX_POWER_0dBm to LMAC154_TX_POWER_14dBm
+ *
+*******************************************************************************/
+lmac154_tx_power_t lmac154_getTxPower(void);
+
+/****************************************************************************
+ * @brief  Set tx data rate (default LMAC154_DATA_RATE_250K)
+ *         The maximum tx mpdu length is 127 bytes for 250kbps tx data rate, and 255 bytes for others
+ *
+ * @param  rate: LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxDataRate(lmac154_data_rate_t rate);
+
+/****************************************************************************
+ * @brief  Enable auto rx data rate (default disabled)
+ *         The maximum rx mpdu length is 127 bytes for 250kbps rx data rate, and 255 bytes for others
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAutoRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Disable auto rx data rate (default disabled)
+ *         The rx data rate is 250kbps, and the maximum rx mpdu length is 127 bytes
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAutoRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Get rx data rate
+ *
+ * @param  None
+ *
+ * @return LMAC154_DATA_RATE_250K, LMAC154_DATA_RATE_500K, LMAC154_DATA_RATE_1M, or LMAC154_DATA_RATE_2M
+ *
+*******************************************************************************/
+lmac154_data_rate_t lmac154_getRxDataRate(void);
+
+/****************************************************************************
+ * @brief  Set CCA mode (default LMAC154_CCA_MODE_ED_AND_CS)
+ *
+ * @param  mode: LMAC154_CCA_MODE_ED, LMAC154_CCA_MODE_CS, LMAC154_CCA_MODE_ED_AND_CS, or LMAC154_CCA_MODE_ED_OR_CS
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCCAMode(lmac154_cca_mode_t mode);
+
+/****************************************************************************
+ * @brief  Set CCA ED threshold (default -71dBm)
+ *
+ * @param  threshold: ED threshold ranging from -122 to 5 in dBm
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEDThreshold(int threshold);
+
+/****************************************************************************
+ * @brief  Get CCA ED threshold
+ *
+ * @param  None
+ *
+ * @return ED threshold
+ *
+*******************************************************************************/
+int lmac154_getEDThreshold(void);
+
+/****************************************************************************
+ * @brief  Run CCA
+ *
+ * @param  rssi: rssi output ranging from -122 to 5 in dBm
+ *
+ * @return CCA result: 0: channel idle, 1: channel busy
+ *
+*******************************************************************************/
+uint8_t lmac154_runCCA(int *rssi);
+
+/****************************************************************************
+ * @brief  Set PAN ID (default 0x4321)
+ *
+ * @param  pid: PAN ID
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setPanId(uint16_t pid);
+void lmac154_set2ndPanId(uint16_t pid);
+
+/****************************************************************************
+ * @brief  Get PAN ID
+ *
+ * @param  None
+ *
+ * @return PAN ID
+ *
+*******************************************************************************/
+uint16_t lmac154_getPanId(void);
+uint16_t lmac154_get2ndPanId(void);
+
+/****************************************************************************
+ * @brief  Set 16-bit short address (default 0x0000)
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setShortAddr(uint16_t sadr);
+void lmac154_set2ndShortAddr(uint16_t sadr);
+
+/****************************************************************************
+ * @brief  Get 16-bit short address
+ *
+ * @param  None
+ *
+ * @return 16-bit short address
+ *
+*******************************************************************************/
+uint16_t lmac154_getShortAddr(void);
+uint16_t lmac154_get2ndShortAddr(void);
+
+/****************************************************************************
+ * @brief  Set 64-bit long address (default 0xACDE4800_00000002)
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setLongAddr(uint8_t *ladr);
+void lmac154_set2ndLongAddr(uint8_t *ladr);
+
+/****************************************************************************
+ * @brief  Get 64-bit long address
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getLongAddr(uint8_t *ladr);
+void lmac154_get2ndLongAddr(uint8_t *ladr);
+
+/****************************************************************************
+ * @brief  Enable frame type filtering (default disabled)
+ *         Will only receive specified frame types
+ *
+ * @param  frame_types: any combination of LMAC154_FRAME_TYPE_XXX (BEACON, DATA, ACK, or CMD), via bitwise OR ('|') operation
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableFrameTypeFiltering(uint8_t frame_types);
+
+/****************************************************************************
+ * @brief  Disable frame type filtering (default disabled)
+ *         Will receive all valid frame types (BEACON, DATA, ACK, or CMD)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableFrameTypeFiltering(void);
+
+/****************************************************************************
+ * @brief  Set rx reject policy
+ *
+ * @param policy : enum lmac154_rx_reject_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxRejectPolicy(lmac154_rx_reject_policy_t policy);
+
+/****************************************************************************
+ * @brief  Get rx reject policy
+ *
+ * @param None
+ *
+ * @return Rx reject policy
+ *
+*******************************************************************************/
+lmac154_rx_reject_policy_t lmac154_getRxRejectPolicy(void);
+
+/****************************************************************************
+ * @brief  set rx accept policy
+ *
+ *
+ * @param policy : enum lmac154_rx_accept_policy_t
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxAcceptPolicy(lmac154_rx_accept_policy_t policy);
+
+/****************************************************************************
+ * @brief  get rx accept policy
+ *
+ *
+ * @param None
+ *
+ * @return lmac154_rx_accept_policy : enum lmac154_rx_accept_policy_t
+ *
+*******************************************************************************/
+lmac154_rx_accept_policy_t lmac154_getRxAcceptPolicy(void);
+
+#ifdef BL702
+/****************************************************************************
+ * @brief  Set external PA
+ *         Restriction: txpin % 5 != rxpin % 5
+ *
+ * @param  txpin: tx pin ranging from 0 to 31
+ * @param  rxpin: rx pin ranging from 0 to 31
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setExtPA(uint32_t txpin, uint32_t rxpin);
+#endif
+
+/****************************************************************************
+ * @brief  Get RF state
+ *
+ * @param  None
+ *
+ * @return LMAC154_RF_STATE_RX, LMAC154_RF_STATE_RX_DOING, LMAC154_RF_STATE_TX, or LMAC154_RF_STATE_IDLE
+ *
+*******************************************************************************/
+lmac154_rf_state_t lmac154_getRFState(void);
+
+/****************************************************************************
+ * @brief  Enable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableCoex(void);
+
+/****************************************************************************
+ * @brief  Disable the coexistence of zigbee and other wireless modules (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableCoex(void);
+
+/****************************************************************************
+ * @brief  Check if coexistence is enabled
+ *
+ * @param  None
+ *
+ * @return true if coexistence is enabled, false otherwise
+ *
+ *******************************************************************************/
+bool lmac154_isCoexEnabled(void);
+
+/****************************************************************************
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setCoexPriority(bool is_rx_on_after_rx_abort_enable, uint32_t tx_priority,
+    uint32_t rx_unicast_priority, uint32_t rx_sfd_priority, uint32_t rx_idle_priority);
+
+/****************************************************************************
+ * @brief  set m154 module coexistence priority
+ *
+ * @param  is_rx_on_after_rx_abort_enable, enable RX after falling edge of RX abort if rx_abort_en is 0.
+ * @param  tx_priority, priority when TX MPDU is being transmitted. (0 ~ 15)
+ * @param  rx_unicast_priority, priority when RX unicast packet is being received. (0 ~ 15)
+ * @param  rx_sfd_priority, priority when RX SFD is detected (0 ~ 15)
+ * @param  rx_idle_priority, priority when Rx is IDLE (0 ~ 15)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_getCoexPriority(bool * is_rx_on_after_rx_abort_enable, uint32_t * tx_priority,
+    uint32_t * rx_unicast_priority, uint32_t * rx_sfd_priority, uint32_t * rx_idle_priority);
+
+/****************************************************************************
+ * @brief  Enable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableTxAbortInt(void);
+
+/****************************************************************************
+ * @brief  Disable TX abort interrupt
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableTxAbortInt(void);
+
+/****************************************************************************
+ * @brief  Enable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableHwAutoTxAck(void);
+
+/****************************************************************************
+ * @brief  Disable auto transmission of ack frame by hardware (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableHwAutoTxAck(void);
+
+/****************************************************************************
+ * @brief  Get whether hardware auto transmission of ack frame is enabled
+ *
+ * @param  None
+ *
+ * @return ture, enabled
+ *
+*******************************************************************************/
+bool lmac154_isHwAutoTxAckEnabled(void);
+
+/****************************************************************************
+ * @brief  Enable lmac154_ackEvent (default enabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableAckEvent(void);
+
+/****************************************************************************
+ * @brief  Disable lmac154_ackEvent (default enabled)
+ *         Will raise lmac154_rxDoneEvent instead when ack is received
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableAckEvent(void);
+
+/****************************************************************************
+ * @brief  Enable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Disable lmac154_rxStartEvent (default disabled)
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Enable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxMHREvent(void);
+
+/****************************************************************************
+ * @brief  Disable MAC header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxMHREvent(void);
+
+/****************************************************************************
+ * @brief  Enable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxSecMHREvent(void);
+
+/****************************************************************************
+ * @brief  Disable MAC Security header received event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxSecMHREvent(void);
+
+/****************************************************************************
+ * @brief  Enable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableReqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Disable Req enh-ack event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableReqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Get the receiving or received mpdu length in bytes (crc included)
+ *
+ * @param  None
+ *
+ * @return The receiving or received mpdu length
+ *
+*******************************************************************************/
+uint8_t lmac154_getRxLength(void);
+
+/****************************************************************************
+ * @brief  Read rx data (crc not included)
+ *
+ * @param  buf: pointer to data buffer
+ * @param  offset: data offset ranging from 0 to 252 in bytes
+ * @param  len: data length ranging from 1 to 253-offset in bytes
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxData(uint8_t *buf, uint8_t offset, uint8_t len);
+
+/****************************************************************************
+ * @brief  Read rx crc
+ *
+ * @param  crc: byte array to carry rx crc
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_readRxCrc(uint8_t crc[2]);
+
+/****************************************************************************
+ * @brief  Set the maximum wait time for ack frame (default 864us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setAckWaitTime(uint16_t time_us);
+
+/****************************************************************************
+ * @brief  Get the maximum wait time for imm-ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getAckWaitTime(void);
+
+/****************************************************************************
+ * @brief  Set the maximum wait time for enh-ack ack frame (default 1500us)
+ *
+ * @param  time_us: maximum wait time
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setEnhAckWaitTime(uint16_t time_us);
+
+/****************************************************************************
+ * @brief  Get the maximum wait time for enh-ack ack frame
+ *
+ * @param  None
+ *
+ * @return time_us: maximum wait time
+ *
+*******************************************************************************/
+uint16_t lmac154_getEnhAckWaitTime(void);
+
+/****************************************************************************
+ * @brief  Set the maximum and minimum CSMA-CA backoff exponent
+ *
+ * @param  max_be: maximum BE ranging from 3 to 8, default 5
+ * @param  min_be: minimum BE ranging from 0 to max_be, default 3
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setBE(uint8_t max_be, uint8_t min_be);
+
+/****************************************************************************
+ * @brief  Set maximum CSMA backoff
+ *
+ * @param  maxBackoff: maximum CSMA backoff
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setMaxCsmaBackoff(uint8_t maxBackoff);
+
+/****************************************************************************
+ * @brief  Set tx-rx transition time
+ *
+ * @param  time: us
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setTxRxTransTime(uint8_t timeInUs);
+
+/****************************************************************************
+ * @brief  Enable Rx filtering (default enabled)
+ *         Will only receive frames that pass crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_enableRxFiltering(void);
+
+/****************************************************************************
+ * @brief  Disable rx filtering (default enabled)
+ *         Will receive all frames ignoring crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_disableRxFiltering(void);
+
+/****************************************************************************
+ * @brief  Enable/Disable rx filtering (default enabled) for dual stacks
+ *         Will receive all frames ignoring crc check
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setRxFiltering(bool is_enable);
+
+uint64_t lmac154_get_rx_start_timestamp(void);
+uint64_t lmac154_get_rx_done_timestamp(void);
+uint64_t lmac154_get_tx_done_timestamp(void);
+
+#if defined (BL702) || defined (BL702L) || defined (BL616)
+bool lmac154_fptSetMaxNum(uint32_t shortAddrNum, uint32_t longAddrNum);
+#endif
+
+/****************************************************************************
+ * @brief  Run AES CCM
+ *
+ * @param  mode: LMAC154_AES_MODE_ENCRYPT or LMAC154_AES_MODE_DECRYPT
+ * @param  a_data: pointer to additional authentication data buffer
+ * @param  a_len: length of additional authentication data in bytes
+ * @param  nonce: pointer to 13-byte nonce buffer
+ * @param  key: pointer to 4-word key buffer
+ * @param  mic_len: LMAC154_MIC_LEN_4, LMAC154_MIC_LEN_8, LMAC154_MIC_LEN_12, or LMAC154_MIC_LEN_16
+ * @param  mic: pointer to mic buffer
+ * @param  input_data: pointer to input data buffer
+ * @param  output_data: pointer to output data buffer
+ * @param  len: length of input data in bytes
+ *
+ * @return The error code
+ *
+*******************************************************************************/
+lmac154_aes_status_t lmac154_runAESCCM(lmac154_aes_mode_t mode,
+                                       const uint8_t *a_data,
+                                       uint8_t a_len,
+                                       const uint8_t *nonce,
+                                       const uint32_t *key,
+                                       lmac154_aes_mic_len_t mic_len,
+                                       uint32_t *mic,
+                                       const uint32_t *input_data,
+                                       uint32_t *output_data,
+                                       uint8_t len);
+
+/* hardware frame pending table (256 bytes) */
+/* shared by short addresses and long addresses (supports up to 128 short addresses or 32 long addresses or mixed) */
+/* used by hardware to set the frame pending bit of hw auto tx ack */
+/* if the address is not found in the table (e.g. not set or removed), the frame pending bit of hw auto tx ack is 1 */
+
+/****************************************************************************
+ * @brief  Add (or update) the key-value pair {sadr: pending} to (in) the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetShortAddrPending(uint16_t sadr, uint8_t pending);
+
+/****************************************************************************
+ * @brief  Add (or update) the key-value pair {ladr: pending} to (in) the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_NO_RESOURCE
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptSetLongAddrPending(uint32_t *xaddr, uint8_t pending);
+
+/****************************************************************************
+ * @brief  Get the corresponding frame pending bit of the short address in the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetShortAddrPending(uint16_t sadr, uint8_t *pending);
+
+/****************************************************************************
+ * @brief  Get the corresponding frame pending bit of the long address in the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ * @param  pending: value of the corresponding frame pending bit
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptGetLongAddrPending(uint32_t *xaddr, uint8_t *pending);
+
+/****************************************************************************
+ * @brief  Remove the key-value pair {sadr: pending} from the frame pending table
+ *
+ * @param  sadr: 16-bit short address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveShortAddr(uint16_t sadr);
+
+/****************************************************************************
+ * @brief  Remove the key-value pair {ladr: pending} from the frame pending table
+ *
+ * @param  ladr: pointer to 64-bit long address
+ *
+ * @return LMAC154_FPT_STATUS_SUCCESS or LMAC154_FPT_STATUS_ADDR_NOT_FOUND
+ *
+*******************************************************************************/
+lmac154_fpt_status_t lmac154_fptRemoveLongAddr(uint32_t *ladr);
+
+/****************************************************************************
+ * @brief  Get short address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetShortAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************
+ * @brief  Get long address list in the frame pending table
+ *
+ * @param  list: pointer to list buffer
+ * @param  entry_num: number of entries
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptGetLongAddrList(void *list, uint8_t *entry_num);
+
+/****************************************************************************
+ * @brief  Set frame pending bit according to frame pending table, or force to set to 1
+ *
+ * @param  force: 0: set according to frame pending table (default), 1: force to set to 1
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptForcePending(uint8_t force);
+
+/****************************************************************************
+ * @brief  Clear the frame pending table
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptClear(void);
+
+/****************************************************************************
+ * @brief  Print the frame pending table using specified print function
+ *
+ * @param  print_func: user specified print function
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_fptDump(int print_func(const char *fmt, ...));
+
+/* functions below are callback functions running in the interrupt context */
+/* should be implemented by user if needed */
+
+/****************************************************************************
+ * @brief  Tx Done Event
+ *         Will be raised after calling lmac154_triggerTx
+ *
+ * @param  tx_status: LMAC154_TX_STATUS_XXX (TX_FINISHED, CSMA_FAILED, TX_ABORTED, or HW_ERROR)
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_txDoneEvent(lmac154_tx_status_t tx_status);
+
+/****************************************************************************
+ * @brief  Ack Event
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  frame_pending: frame pending bit in ack frame
+ * @param  seq_num: sequence number in ack frame
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackEvent(uint8_t ack_received, uint8_t frame_pending, uint8_t seq_num);
+
+/****************************************************************************
+ * @brief  Ack Event with ack frame
+ *         Will be raised after calling lmac154_triggerTx(AR bit = 1)
+ *
+ * @param  ack_received: 0: no ack, 1: ack received
+ * @param  rx_buf: pointer to the ack frame buffer
+ * @param  len: ACK frame length
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_ackFrameEvent(uint8_t ack_received, uint8_t *rx_buf, uint8_t len);
+
+/****************************************************************************
+ * @brief  Rx Done Event
+ *         Will be raised when a frame is received on lmac154_getInterruptHandler used
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received mpdu length in bytes (crc included)
+ * @param  crc_fail: 0: crc pass, 1: crc fail
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxDoneEvent(uint8_t *rx_buf, uint8_t rx_len, uint32_t crc_fail);
+
+/****************************************************************************
+ * @brief  Rx Start Event
+ *         Will be raised when rx on MAC sublayer starts
+ *         lmac154_getRxLength is available because it is obtained from PHY layer
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxStartEvent(void);
+
+/****************************************************************************
+ * @brief  Hardware auto tx ack done event
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_hwAutoTxAckDoneEvent(void);
+
+/****************************************************************************
+ * @brief  A 2015 version unicast packet received and enh-ack is required to respond
+ *
+ * @param  None
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_reqEnhAckEvent(void);
+
+/****************************************************************************
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+/****************************************************************************
+ * @brief  Rx Mac header Event
+ *         Will be raised when a frame is received
+ *
+ * @param  rx_buf: pointer to rx buffer
+ * @param  rx_len: received length when event occured
+ * @param  pkt_len: the total lenght of receiving packet
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_rxSecMhrEvent(uint8_t *rx_buf, uint8_t rx_len, uint8_t pkt_len);
+
+#endif

--- a/include/bouffalolab/bl70xl/lmac154/lmac154_fpt.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154_fpt.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FPT_H__
+#define __LMAC154_FPT_H__
+
+typedef enum {
+	LMAC154_FPT_DATAREQ = 0,
+	LMAC154_FPT_DATAREQ_DATA = 1,
+	LMAC154_FPT_ANY = 2
+} lmac154_fptMode_t;
+
+typedef enum {
+	LMAC154_FPT_RESULT_NONE = 0,
+	LMAC154_FPT_RESULT_FALSE = 1,
+	LMAC154_FPT_RESULT_TRUE = 2,
+	LMAC154_FPT_RESULT_BUSY = 3
+} lmac154_fptResult_t;
+
+typedef union {
+	struct {
+		uint32_t isExist: 1;
+		uint32_t isFramePended: 1;
+		uint32_t nbrIdx: 7;
+		uint32_t isSearchDone: 1;
+		uint32_t unused: 22;
+	} bf;
+
+	uint32_t word;
+
+} lmac154_fptSearchResult_t;
+
+void lmac154_setFramePendingSourceMatch(bool isEnable);
+
+/****************************************************************************//**
+ * @brief  Set frame pending table mode
+ *
+ * @param  mode: 
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingMode(lmac154_fptMode_t mode);
+
+/****************************************************************************//**
+ * @brief  Get frame pending table mode
+ *
+ * @param  mode: frame pending table working mode
+ *
+ * @return None
+ *
+*******************************************************************************/
+lmac154_fptMode_t lmac154_getFramePendingMode(void);
+
+/****************************************************************************//**
+ * @brief  Get frame pending table result when receive a packet
+ *
+ * @param  tout, timeout to get result with macro second unit
+ * 
+ * @return Result
+ *
+*******************************************************************************/
+lmac154_fptSearchResult_t lmac154_framePendingResult(uint32_t tout);
+
+#endif

--- a/include/bouffalolab/bl70xl/lmac154/lmac154_fpt.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154_fpt.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FPT_H__
+#define __LMAC154_FPT_H__
+
+typedef enum {
+    LMAC154_FPT_DATAREQ             = 0,
+    LMAC154_FPT_DATAREQ_DATA        = 1,
+    LMAC154_FPT_ANY                 = 2
+} lmac154_fptMode_t;
+
+typedef enum {
+    LMAC154_FPT_RESULT_NONE         = 0,
+    LMAC154_FPT_RESULT_FALSE        = 1,
+    LMAC154_FPT_RESULT_TRUE         = 2,
+    LMAC154_FPT_RESULT_BUSY         = 3
+} lmac154_fptResult_t;
+
+void lmac154_setFramePendingSourceMatch(bool isEnable);
+
+/****************************************************************************
+ * @brief  Set frame pending table mode
+ *
+ * @param  mode:
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingMode(lmac154_fptMode_t mode);
+
+/****************************************************************************
+ * @brief  Get frame pending table mode
+ *
+ * @param  None
+ *
+ * @return lmac154_fptMode_t
+ *
+*******************************************************************************/
+lmac154_fptMode_t lmac154_getFramePendingMode(void);
+
+/****************************************************************************
+ * @brief  Get frame pending table result when receive a packet
+ *
+ * @param  tout: timeout to do frame pending table search
+ *
+ * @param  isFramePended: whether frame pending is set for searched on received packet
+ *
+ * @return int: return the index of neighbor table if matched; else, return -1
+ *
+*******************************************************************************/
+int lmac154_framePendingResult(uint32_t tout, bool * isFramePended);
+
+#if defined BL618DG
+/****************************************************************************
+ * @brief  Set frame pending bit result if neighbor search fails
+ *
+ * @param  bFramePending, frame pending bit, true by default.
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_setFramePendingBitIfNeighborSearchFails(bool bFramePending);
+
+/****************************************************************************
+ * @brief  Get frame pending bit result if neighbor search fails
+ *
+ * @param  None
+ *
+ * @return True, if neighbor search fails.
+ *
+*******************************************************************************/
+bool lmac154_getFramePendingBitIfNeighborSearchFails(void);
+#endif
+#endif

--- a/include/bouffalolab/bl70xl/lmac154/lmac154_frame.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154_frame.h
@@ -1,0 +1,550 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_FRAME_H__
+#define __LMAC154_FRAME_H__
+
+/****************************************************************************
+ * @file lmac154_frame.h
+ * @brief IEEE 802.15.4 Frame Parsing and Analysis Module
+ ******************************************************************************/
+
+/*============================================================================
+ * Frame Control Field Definitions
+ *============================================================================*/
+
+/* Frame Type */
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK       (7)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_BEACON     (0)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA       (1)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK        (2)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD        (3)
+#define LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP        (5)
+
+/* Security and Pending */
+#define LMAC154_FRAME_SECURITY_MASK                 (1 << 3)
+#define LMAC154_FRAME_FRAME_PENDING_MASK            (1 << 4)
+#define LMAC154_FRAME_ACK_REQUEST_MASK              (1 << 5)
+#define LMAC154_FRAME_PANID_COMPRESSION             (1 << 6)
+#define LMAC154_FRAME_SEQ_SUPPRESSION_MASK          (1 << 8)
+#define LMAC154_FRAME_IE_MASK                       (1 << 9)
+
+/* Addressing Fields */
+#define LMAC154_FRAME_ADDR_DEST_NONE                (0 << 10)
+#define LMAC154_FRAME_ADDR_DEST_SHORT               (2 << 10)
+#define LMAC154_FRAME_ADDR_DEST_EXT                 (3 << 10)
+#define LMAC154_FRAME_ADDR_DEST_MASK                (3 << 10)
+
+#define LMAC154_FRAME_VERSION_MASK                  (3 << 12)
+#define LMAC154_FRAME_VERSION_2003                  (0 << 12)
+#define LMAC154_FRAME_VERSION_2006                  (1 << 12)
+#define LMAC154_FRAME_VERSION_2015                  (2 << 12)
+
+#define LMAC154_FRAME_ADDR_SRC_NONE                 (0 << 14)
+#define LMAC154_FRAME_ADDR_SRC_SHORT                (2 << 14)
+#define LMAC154_FRAME_ADDR_SRC_EXT                  (3 << 14)
+#define LMAC154_FRAME_ADDR_SRC_MASK                 (3 << 14)
+
+/* MPP (Multi-Purpose Protocol) Frame Specific */
+#define LMAC154_FRAME_MPP_LONG_FRAME_BIT            (1 << 3)
+#define LMAC154_FRAME_MPP_SECURITY_BIT              (1 << 9)
+#define LMAC154_FRAME_MPP_ACK_REQ                   (1 << 14)
+
+/* Auxiliary Security Header */
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_MASK          (3 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_0             (0 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_1             (1 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_2             (2 << 3)
+#define LMAC154_FRAME_AUX_KEY_ID_MODE_3             (3 << 3)
+
+/*============================================================================
+ * Frame Check Macros
+ *============================================================================*/
+
+/* Frame Type Check */
+#define LMAC154_FRAME_IS_BEACON(x)                  (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_BEACON)
+#define LMAC154_FRAME_IS_DATA(x)                    (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_DATA)
+#define LMAC154_FRAME_IS_ACK(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_ACK)
+#define LMAC154_FRAME_IS_CMD(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_CMD)
+#define LMAC154_FRAME_IS_MPP(x)                     (((x) & LMAC154_FRAME_CONTROL_FRAME_TYPE_MASK) == LMAC154_FRAME_CONTROL_FRAME_TYPE_MPP)
+
+/* Security Check */
+#define LMAC154_FRAME_IS_NORMAL_SECURITY(x)         ((x & LMAC154_FRAME_SECURITY_MASK) == LMAC154_FRAME_SECURITY_MASK)
+#define LMAC154_FRAME_IS_MPP_LONG_FRAME(x)          ((x & LMAC154_FRAME_MPP_LONG_FRAME_BIT) == LMAC154_FRAME_MPP_LONG_FRAME_BIT)
+#define LMAC154_FRAME_IS_MPP_SECURITY(x)            (LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_SECURITY_BIT) == LMAC154_FRAME_MPP_SECURITY_BIT)
+#define LMAC154_FRAME_IS_SECURITY_ENABLED(x)        (LMAC154_FRAME_IS_MPP(x) ? LMAC154_FRAME_IS_MPP_SECURITY(x) : LMAC154_FRAME_IS_NORMAL_SECURITY(x))
+
+/* ACK and Pending Check */
+#define LMAC154_FRAME_IS_ACK_REQ(x)                 (((x) & LMAC154_FRAME_ACK_REQUEST_MASK) == LMAC154_FRAME_ACK_REQUEST_MASK)
+#define LMAC154_FRAME_IS_FRAME_PENDED(x)            ((x) & LMAC154_FRAME_FRAME_PENDING_MASK)
+#define LMAC154_FRAME_IS_PANID_COMPRESSED(x)        (((x) & LMAC154_FRAME_PANID_COMPRESSION) == LMAC154_FRAME_PANID_COMPRESSION)
+#define LMAC154_FRAME_IS_SEQ_SUPPRESS(x)            (((x) & LMAC154_FRAME_SEQ_SUPPRESSION_MASK) == LMAC154_FRAME_SEQ_SUPPRESSION_MASK)
+
+/* Enhanced ACK Check */
+#define LMAC154_FRAME_IS_MPP_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP(x) && LMAC154_FRAME_IS_MPP_LONG_FRAME(x) && ((x) & LMAC154_FRAME_MPP_ACK_REQ) == LMAC154_FRAME_MPP_ACK_REQ)
+#define LMAC154_FRAME_IS_ENH_ACK_REQ(x)             (LMAC154_FRAME_IS_MPP_ACK_REQ(x) || (LMAC154_FRAME_IS_ACK_REQ(x) && LMAC154_FRAME_IS_FRAME_2015(x)))
+#define LMAC154_FRAME_IS_IMM_ACK_REQ(x)             (LMAC154_FRAME_IS_ACK_REQ(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* Frame Version Check */
+#define LMAC154_FRAME_IS_FRAME_2015(x)              (((x) & LMAC154_FRAME_VERSION_MASK) == LMAC154_FRAME_VERSION_2015)
+#define LMAC154_FRAME_IS_IE_EXIST(x)                (((x) & LMAC154_FRAME_IE_MASK) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* ACK Type Check */
+#define LMAC154_FRAME_IS_IMM_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && !LMAC154_FRAME_IS_FRAME_2015(x))
+#define LMAC154_FRAME_IS_ENH_ACK(x)                 (LMAC154_FRAME_IS_ACK(x) && LMAC154_FRAME_IS_FRAME_2015(x))
+
+/* Address Type Extraction */
+#define LMAC154_FRAME_GET_DST_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_DEST_MASK)
+#define LMAC154_FRAME_GET_SRC_ADDR_TYPE(x)          ((x) & LMAC154_FRAME_ADDR_SRC_MASK)
+
+typedef struct {
+    uint8_t sec_lvl:3;
+    uint8_t key_id_mode:2;
+    uint8_t frame_counter_sup:1;
+    uint8_t asn_in_nonce:1;
+    uint8_t reserved:1;
+    uint8_t frame_cnt[4];
+    uint8_t key_id[8];
+} __packed lmac154_aux_hdr_t;
+
+typedef struct {
+    uint16_t length:7;
+    uint16_t element_id:8;
+    uint16_t type:1;
+} __packed lmac154_ie_hdr_t;
+
+typedef union {
+    struct {
+        lmac154_ie_hdr_t hdr;
+        uint16_t phase;
+        uint16_t period;
+    } __packed bf;
+    uint8_t bytes[6];
+} __packed lmac154_ie_csl_t;
+
+#define LMAC154_LIFS                    40
+#define LMAC154_SIFS                    12
+#define LMAC154_AIFS                    LMAC154_SIFS
+#define LMAC154_SIFS_MAX_FRAME_SIZE     18
+#define LMAC154_TURNAROUND              12
+#define LMAC154_PKT_MAX_LEN             127
+#define LMAC154_PREAMBLE_LEN            8
+#define LMAC154_SHR_LEN                 10
+#define LMAC154_US_PER_SYMBOL           16
+#define LMAC154_US_PER_SYMBOL_BITS      4
+
+#define LMAC154_CSMA_CA_MIN_BE          3
+#define LMAC154_CSMA_CA_MAX_BE          5
+#define LMAC154_CSMA_CA_MAX_BACKOFF     4
+
+/* Key ID Mode definitions */
+#define LMAC154_KEY_ID_MODE_0                 0
+#define LMAC154_KEY_ID_MODE_1                 1
+#define LMAC154_KEY_ID_MODE_2                 2
+#define LMAC154_KEY_ID_MODE_3                 3
+#define LMAC154_KEY_ID_MODE_4                 4
+
+/* Key ID lengths for different modes */
+#define LMAC154_KEY_ID_LEN_MODE_0             0
+#define LMAC154_KEY_ID_LEN_MODE_1             1
+#define LMAC154_KEY_ID_LEN_MODE_2             5
+#define LMAC154_KEY_ID_LEN_MODE_3             8
+#define LMAC154_KEY_ID_LEN_MODE_4_MIN         0
+#define LMAC154_KEY_ID_LEN_MODE_4_MAX         9
+
+/* IE (Information Element) Definitions */
+#define LMAC154_IE_TERmination2_ID              0x7f
+#define LMAC154_IE_CSL_ID                       0x1a
+
+/* Thread Vendor IE Definitions */
+#define LMAC154_IE_VENDOR_ID                    0x00
+#define LMAC154_IE_THREAD_VENDOR_ID             0x00
+#define LMAC154_IE_THREAD_ENH_ACK_PROBING_IE_ID 0x00
+#define LMAC154_IE_THREAD_HDR_SIZE              4
+
+/**
+ * @brief  32-bit optimized MAC Header parser.
+ * @note   Assumes 'pr' (buffer start) is 32-bit aligned.
+ * Uses single-word access to minimize bus cycles and branch mispredictions.
+ * * @param pr           Pointer to the start of the MAC frame (FCF).
+ * @param a_dest_panid Output pointer to Destination PAN ID.
+ * @param a_dest_sa    Output pointer to Destination Short Address.
+ * @param a_dest_xa    Output pointer to Destination Extended Address.
+ * @param a_src_sa     Output pointer to Source Short Address.
+ * @param a_src_xa     Output pointer to Source Extended Address.
+ */
+static inline uint32_t lmac154_parse_mhr(uint8_t *pr, uint8_t **a_dest_panid, uint8_t **a_dest_sa,
+                                 uint8_t **a_dest_xa, uint8_t **a_src_sa, uint8_t **a_src_xa)
+{
+    /* 1. Single 32-bit load to fetch FCF, Seq, and the start of Dest PAN ID.
+     * This is significantly faster than multiple 8-bit loads on 32-bit architectures. */
+    uint32_t head = *(const uint32_t *)pr;
+    uint32_t fcf  = head & 0xFFFF;
+
+    /* Initial offset: FCF(2) + Sequence Number(1) = 3 */
+    uint32_t offset = 3;
+
+    /* Extract Address Modes and PAN ID Compression bit via bit-shifting */
+    uint32_t dst_mode  = (fcf >> 10) & 0x03;
+    uint32_t src_mode  = (fcf >> 14) & 0x03;
+    uint32_t pan_comp  = (fcf >> 6)  & 0x01;
+
+    /* 2. Parse Destination Address Field (PAN ID + Address) */
+    if (dst_mode) {
+        /* Map Mode to length: Mode 2 (Short) -> 2 bytes, Mode 3 (Ext) -> 8 bytes.
+         * Using a ternary here allows compilers to use CMOV (conditional move)
+         * instructions to avoid pipeline stalls. */
+        uint32_t dst_addr_len = (dst_mode == 3) ? 8 : 2;
+
+        /* Destination PAN ID always follows Sequence Number at offset 3 */
+        *a_dest_panid = pr + 3;
+
+        /* Assign address pointers based on mode. Dest Addr starts at offset 5. */
+        if (dst_mode == 2) {
+            *a_dest_sa = pr + 5;
+        } else {
+            *a_dest_xa = pr + 5;
+        }
+
+        /* Update offset: 3 (FCF+Seq) + 2 (PAN) + AddrLength */
+        offset = 5 + dst_addr_len;
+    }
+
+    /* 3. Source PAN ID Compression Logic (Standard 2003/2006/2015 common subset).
+     * If compression bit is 0, a 2-byte Source PAN ID exists before the Source Addr. */
+    if (!pan_comp) {
+        offset += 2;
+    }
+
+    /* 4. Parse Source Address Field */
+    if (src_mode == 2) {
+        /* Source Short Address (2 bytes) */
+        *a_src_sa = pr + offset;
+    } else if (src_mode == 3) {
+        /* Source Extended Address (8 bytes) */
+        *a_src_xa = pr + offset;
+    }
+
+    return offset;
+}
+
+/**
+ * lmac154_parse_mhr_2015 - Strict MHR parser based on 802.15.4-2015 Table 7-2
+ * @pr: Pointer to frame start (MUST be 32-bit aligned)
+ * ... (output pointers)
+ *
+ * Returns the total length of the MHR in bytes.
+ */
+static inline uint32_t lmac154_parse_mhr_2015(uint8_t *pr,
+                       uint8_t **a_dest_panid, uint8_t **a_dest_sa,
+                       uint8_t **a_dest_xa, uint8_t **a_src_panid,
+                       uint8_t **a_src_sa, uint8_t **a_src_xa)
+{
+    uint32_t head = *(const uint32_t *)pr;
+    uint16_t fcf = (uint16_t)(head & 0xffff);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+    uint32_t offset;
+    bool has_dst_pan = false;
+    bool has_src_pan = false;
+
+    /* 1. Sequence Number Suppression (Version 2 feature) */
+    offset = (fcf & (1 << 8)) ? 2 : 3;
+
+    /* 2. Strict Table 7-2 Logic Implementation */
+    if (dst_mode == 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 1);
+    } else if (dst_mode > 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 0);
+    } else if (dst_mode == 0 && src_mode > 0) {
+        has_src_pan = (pan_comp == 0);
+    } else if (dst_mode == 3 && src_mode == 3) {
+        /* Extended <-> Extended: Row 7 & 8 */
+        has_dst_pan = (pan_comp == 0);
+        has_src_pan = false;
+    } else {
+        /* Mixed or Short <-> Short: Row 9-14 */
+        if (pan_comp == 0) {
+            has_dst_pan = true;
+            has_src_pan = true;
+        } else {
+            has_dst_pan = true;
+            has_src_pan = false;
+        }
+    }
+
+    /* 3. Extract Destination Fields */
+    if (has_dst_pan) {
+        *a_dest_panid = pr + offset;
+        offset += 2;
+    }
+
+    if (dst_mode == 2) {
+        *a_dest_sa = pr + offset;
+        offset += 2;
+    } else if (dst_mode == 3) {
+        *a_dest_xa = pr + offset;
+        offset += 8;
+    }
+
+    /* 4. Extract Source Fields */
+    if (has_src_pan) {
+        *a_src_panid = pr + offset;
+        offset += 2;
+    }
+
+    if (src_mode == 2) {
+        *a_src_sa = pr + offset;
+        offset += 2;
+    } else if (src_mode == 3) {
+        *a_src_xa = pr + offset;
+        offset += 8;
+    }
+
+    return offset;
+}
+
+/**
+ * lmac154_get_mhr_len - MHR length for 802.15.4-2003/2006
+ * @pkt: Pointer to frame start
+ */
+static inline uint32_t lmac154_get_mhr_len(const uint8_t *pkt)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+    uint32_t pos = 3; /* FCF(2) + Seq(1), Legacy always has Seq */
+
+    /* Destination Field */
+    if (dst_mode) {
+        pos += 2; /* Destination PAN ID always present if DstMode > 0 */
+        pos += (dst_mode == 3 ? 8 : 2);
+    }
+
+    /* Source Field */
+    if (src_mode) {
+        /* In Legacy: Source PAN is omitted ONLY IF:
+         * Both addresses are present AND PanComp is set to 1.
+         */
+        if (!dst_mode || !pan_comp) {
+            pos += 2; /* Source PAN ID present */
+        }
+        pos += (src_mode == 3 ? 8 : 2);
+    }
+
+    return pos;
+}
+
+/**
+ * lmac154_get_mhr_len_2015 - MHR length for 802.15.4-2015 (Strict Table 7-2)
+ * @pkt: Pointer to frame start
+ */
+static inline uint32_t lmac154_get_mhr_len_2015(const uint8_t *pkt)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint32_t dst_mode = (fcf >> 10) & 0x03;
+    uint32_t src_mode = (fcf >> 14) & 0x03;
+    uint32_t pan_comp = (fcf >> 6) & 0x01;
+
+    /* Sequence Number Suppression: Bit 8 */
+    uint32_t pos = (fcf & (1 << 8)) ? 2 : 3;
+
+    bool has_dst_pan = false;
+    bool has_src_pan = false;
+
+    /* Strict Mapping of Table 7-2 */
+    if (dst_mode == 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 1); /* Row 1 & 2 */
+    } else if (dst_mode > 0 && src_mode == 0) {
+        has_dst_pan = (pan_comp == 0); /* Row 3 & 4 */
+    } else if (dst_mode == 0 && src_mode > 0) {
+        has_src_pan = (pan_comp == 0); /* Row 5 & 6 */
+    } else if (dst_mode == 3 && src_mode == 3) {
+        has_dst_pan = (pan_comp == 0); /* Row 7 & 8: Extended-to-Extended */
+    } else {
+        /* Mixed or Short-to-Short: Rows 9-14 */
+        if (pan_comp == 0) {
+            has_dst_pan = true;  /* Row 9, 10, 11 */
+            has_src_pan = true;
+        } else {
+            has_dst_pan = true;  /* Row 12, 13, 14 */
+            has_src_pan = false;
+        }
+    }
+
+    if (has_dst_pan) pos += 2;
+    if (dst_mode > 0) pos += (dst_mode == 3 ? 8 : 2);
+    if (has_src_pan) pos += 2;
+    if (src_mode > 0) pos += (src_mode == 3 ? 8 : 2);
+
+    return pos;
+}
+
+/**
+ * @brief  Calculates the Auxiliary Security Header length.
+ * @param  pkt: Pointer to the start of the frame.
+ * @param  mhr_len: The offset where Aux Header starts (output of lmac154_get_mhr_len).
+ * @return Length of the Security Header (5, 6, 10, or 14 bytes).
+ */
+static inline uint32_t lmac154_get_aux_sec_len(uint8_t *pkt, uint32_t mhr_len)
+{
+    uint16_t fcf = pkt[0] | (pkt[1] << 8);
+    uint8_t sec_ctrl;
+    uint32_t key_id_mode;
+    uint32_t extra;
+
+    /* If Security Enabled bit (Bit 3) is not set, length is 0 */
+    if (!(fcf & 0x0008)) {
+        return 0;
+    }
+
+    /* Read Security Control byte at the calculated offset */
+    sec_ctrl = pkt[mhr_len];
+    key_id_mode = (sec_ctrl >> 3) & 0x03;
+
+    /* Fast lookup using a packed 32-bit constant (Register-based LUT):
+     * modes 0->0, 1->1, 2->5, 3->9 bytes extra for KeyID.
+     */
+    extra = (0x09050100 >> (key_id_mode << 3)) & 0xFF;
+
+    /* Base Security Header is 5 bytes: Security Control(1) + Frame Counter(4) */
+    return 5 + extra;
+}
+
+/**
+ * lmac154_parse_aux_hdr - Safely map and return the next position
+ * @pkt: Pointer to frame start (32-bit aligned)
+ * @mhr_len: Offset to security header
+ * @p_aux_hdr: Output pointer
+ *
+ * Return: Next position pointer.
+ */
+static inline uint32_t lmac154_parse_aux_hdr(uint8_t *pkt, uint32_t mhr_len,
+                        lmac154_aux_hdr_t **p_aux_hdr)
+{
+    uint32_t len;
+    uint8_t *pos = pkt + mhr_len;
+
+    len = lmac154_get_aux_sec_len(pkt, mhr_len);
+    if (len == 0) {
+        if (p_aux_hdr)
+            *p_aux_hdr = NULL;
+        return 0;
+    }
+
+    if (p_aux_hdr)
+        *p_aux_hdr = (lmac154_aux_hdr_t *)pos;
+
+    return len;
+}
+
+/**
+ * lmac154_traverse_ie - IE section traversal
+ * @ie_start: Pointer to the start of IE section
+ * @ie_len: Maximum length to search (buffer limit)
+ * @target_id: Target IE ID to locate; @found_ie is set on first match
+ * @found_ie: Output pointer to the matched IE header (NULL if not found)
+ *
+ * Return: Total bytes from ie_start to the end of the Termination IE.
+ * Always traverses the full IE section regardless of target match.
+ * Returns 0 if a structural error (truncation) is detected.
+ */
+static inline uint32_t lmac154_traverse_ie(uint8_t *ie_start, uint32_t ie_len,
+                       uint8_t target_id, lmac154_ie_hdr_t **found_ie)
+{
+    uint8_t *cur = ie_start;
+    uint8_t *limit = ie_start + ie_len;
+
+    if (found_ie)
+        *found_ie = NULL;
+
+    /* Pre-check: Minimal Header IE is 2 bytes */
+    while (cur + 2 <= limit) {
+        /* RISC-V Safe: Byte-by-byte 16-bit header fetch
+         * Bits: [0:6] Length, [7:14] ID, [15] Type
+         */
+        uint32_t hdr = (uint32_t)(cur[0] | (cur[1] << 8));
+        uint32_t len = hdr & 0x7F;
+        uint32_t id  = (hdr >> 7) & 0xFF;
+        uint32_t total_sz = len + 2;
+
+        /* 1. Fast Termination Check: 0x7E/0x7F both match (id & 0xFE) == 0x7E */
+        if ((id & 0xFE) == 0x7E) {
+            cur += 2;
+            break;
+        }
+
+        /* 2. Boundary Validation */
+        if (cur + total_sz > limit)
+            return 0;
+
+        /* 3. Target Matching - record first occurrence, continue traversal */
+        if (id == target_id) {
+            if (found_ie && !*found_ie)
+                *found_ie = (lmac154_ie_hdr_t *)cur;
+        }
+
+        /* 4. Advance pointer */
+        cur += total_sz;
+    }
+
+    /* Return total length of all traversed IEs (including termination) */
+    return (uint32_t)(cur - ie_start);
+}
+
+/**
+ * @brief  Generate CSL IE and return the computed phase value.
+ * @note   CslPhase = ceil((sample_time - tx_sfd_sym) % period / 10),
+ *         in 10-symbol units per IEEE 802.15.4-2015.
+ * @param  csl_period     CSL period in 10-symbol units.
+ * @param  csl_sample_time  CSL sample time in symbol count.
+ * @param  csl_ie         Output CSL IE buffer.
+ * @param  tx_sfd_sym     Estimated TX SFD time in symbol count.
+ * @return CSL phase value written to the IE.
+ */
+static inline uint16_t lmac154_gen_csl_ie(uint16_t csl_period, uint32_t csl_sample_time,
+                                           lmac154_ie_csl_t *csl_ie, uint32_t tx_sfd_sym)
+{
+    uint32_t period_sym = (uint32_t)csl_period * 10;
+    uint32_t delta_sym  = (csl_sample_time - tx_sfd_sym) % period_sym;
+    uint16_t csl_phase  = (uint16_t)((delta_sym + 9) / 10);
+
+    csl_ie->bf.hdr.length     = 4;
+    csl_ie->bf.hdr.element_id = LMAC154_IE_CSL_ID;
+    csl_ie->bf.hdr.type       = 0;
+    csl_ie->bf.phase          = csl_phase;
+    csl_ie->bf.period         = csl_period;
+
+    return csl_phase;
+}
+
+#endif /* __LMAC154_FRAME_H__ */

--- a/include/bouffalolab/bl70xl/lmac154/lmac154_lp.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154_lp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_PDS_H__
+#define __LMAC154_PDS_H__
+
+/****************************************************************************//**
+ * @brief  Store registers to backup memory
+ *
+ * @param  retentionMem: retention memory to hold registers configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepStoreRegs(uint32_t *retentionMem);
+
+/****************************************************************************//**
+ * @brief  Restore registers from backup memory
+ *
+ * @param  retentionMem: retention memory hold register configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepRestoreRegs(uint32_t *retentionMem);
+
+#endif

--- a/include/bouffalolab/bl70xl/lmac154/lmac154_lp.h
+++ b/include/bouffalolab/bl70xl/lmac154/lmac154_lp.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2022 Bouffalolab.
+ *
+ * This file is part of
+ *     *** Bouffalolab Software Dev Kit ***
+ *      (see www.bouffalolab.com).
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of Bouffalo Lab nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LMAC154_PDS_H__
+#define __LMAC154_PDS_H__
+
+/****************************************************************************
+ * @brief  Store registers to backup memory
+ *
+ * @param  retentionMem: retention memory to hold registers configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepStoreRegs(uint32_t *retentionMem);
+
+/****************************************************************************
+ * @brief  Restore registers from backup memory
+ *
+ * @param  retentionMem: retention memory hold register configurations
+ *
+ * @return None
+ *
+*******************************************************************************/
+void lmac154_sleepRestoreRegs(uint32_t *retentionMem);
+
+#endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -175,6 +175,14 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "BLE controller for BL702: UART HCI transport"
     doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/73ffff3849ea621dacafdb66835505d6404d7dd8/network/ble/blecontroller_bl702_uarthci
+  - path: lib/bl70x/liblmac154.a
+    sha256: 498a669278ca297bb03f9ce13c013d71ea6aaad814785be116c99eed1ce85e05
+    type: lib
+    version: '1.6.40-2207-g7c727d7bd'
+    url: https://github.com/bouffalolab/bl_iot_sdk-components/raw/73ffff3849ea621dacafdb66835505d6404d7dd8/network/lmac154/lmac154/lib/liblmac154.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "IEEE 802.15.4 MAC/PHY library for BL702 (BL70x)"
+    doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/73ffff3849ea621dacafdb66835505d6404d7dd8/network/lmac154/lmac154
   - path: lib/bl70x/libbl702_rf.a
     sha256: b3d683ffd4c11f58d4413243340817d20a0ea188693b322e936209046519a626
     type: lib

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -191,3 +191,12 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "RF driver library for BL702 (BL70x)"
     doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/73ffff3849ea621dacafdb66835505d6404d7dd8/platform/soc/bl702/bl702_rf
+# BL61x series
+  - path: lib/bl61x/liblmac154_bl616.a
+    sha256: 1ab13b5a9f9aafb02ac7639045c575f158e6502f13b5eae0fad923f59bbd2eb1
+    type: lib
+    version: '2.3.17'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.17/components/wireless/lmac154/lmac154/lib/liblmac154_bl616.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "IEEE 802.15.4 MAC/PHY library for BL616 (BL61x)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.17/components/wireless/lmac154/lmac154

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -78,6 +78,14 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "BLE controller: all roles, 8 connections"
     doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/73ffff3849ea621dacafdb66835505d6404d7dd8
+  - path: lib/bl70xl/liblmac154_bl702l.a
+    sha256: 79ad7526f5d6f17089b95af0016dd6cb0a541dca6c1b4392a6137ac5e786cc2a
+    type: lib
+    version: '1.6.40-2207-g7c727d7bd'
+    url: https://github.com/bouffalolab/bl_iot_sdk-components/raw/73ffff3849ea621dacafdb66835505d6404d7dd8/network/lmac154/lmac154_bl702l/lib/liblmac154_bl702l.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "IEEE 802.15.4 MAC/PHY library for BL702L (BL70XL)"
+    doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/73ffff3849ea621dacafdb66835505d6404d7dd8
   - path: lib/bl70xl/libbl702l_rf.a
     sha256: 66e1e697b34244a2a36e9a001d3838305bde9e8fd0e114bbaee5ee1722a3eea7
     type: lib

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -265,6 +265,14 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "PHY/RF library for BL602 (BL60x)"
     doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.29/drivers/soc/bl602/phyrf
+  - path: lib/bl61x/liblmac154_bl616.a
+    sha256: 971165bcfb478d1093a67dff360bc54fff631e6efa7505b767a9386ffa8d7300
+    type: lib
+    version: '2.3.29'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.29/components/wireless/lmac154/lmac154/lib/liblmac154_bl616.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "IEEE 802.15.4 MAC/PHY library for BL616 (BL61x)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.29/components/wireless/lmac154/lmac154
 # BL61x WiFi MACSW blobs
   - path: lib/bl61x/libmacsw_bl616.a
     sha256: 5e122c6b1c3bc2d604894d6cbfada5cbc8f9ca61e52ba4734c0bf8d38bec6a0a

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -78,6 +78,14 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "BLE controller: all roles, 8 connections"
     doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/a18c0f9215a9490ca2ce4811084b96ee60e4f205
+  - path: lib/bl70xl/liblmac154_bl702l.a
+    sha256: 508c8a18a9972a00700a5a7b1960791b1ea4dc32e0f062511e144f436dc06d14
+    type: lib
+    version: '1.6.40-2226-gf5b2695e1'
+    url: https://github.com/bouffalolab/bl_iot_sdk-components/raw/a18c0f9215a9490ca2ce4811084b96ee60e4f205/network/lmac154/lmac154_bl702l/lib/liblmac154_bl702l.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "IEEE 802.15.4 MAC/PHY library for BL702L (BL70XL)"
+    doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/a18c0f9215a9490ca2ce4811084b96ee60e4f205
   - path: lib/bl70xl/libbl702l_rf.a
     sha256: 09d703c48e1f6e3200c98d07f6003a5813310dddc50aea90d38117e3766d848a
     type: lib

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -175,6 +175,14 @@ blobs:
     license-path: zephyr/blobs/license_sdk.txt
     description: "BLE controller for BL702: UART HCI transport"
     doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/a18c0f9215a9490ca2ce4811084b96ee60e4f205/network/ble/blecontroller_bl702_uarthci
+  - path: lib/bl70x/liblmac154.a
+    sha256: 186e5e91650c3fa9196a038cb5c1d6c351818a1ac5ae5cbab4ae925e0094dc5a
+    type: lib
+    version: '1.6.40-2226-gf5b2695e1'
+    url: https://github.com/bouffalolab/bl_iot_sdk-components/raw/a18c0f9215a9490ca2ce4811084b96ee60e4f205/network/lmac154/lmac154/lib/liblmac154.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "IEEE 802.15.4 MAC/PHY library for BL702 (BL70x)"
+    doc-url: https://github.com/bouffalolab/bl_iot_sdk-components/tree/a18c0f9215a9490ca2ce4811084b96ee60e4f205/network/lmac154/lmac154
   - path: lib/bl70x/libbl702_rf.a
     sha256: 94dd54071072ea241367b094b109f97a85e731e301f94cce3946d89741893ad6
     type: lib


### PR DESCRIPTION
Add lmac154 library headers for IEEE 802.15.4 support, including the main API, function pointer table, and low-power interface definitions.