### PR TITLE
bflb: update .gitignore for Python, macOS and blob artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,26 @@ out/*
 build/*
 .vscode/settings.json
 .settings
+
+# Python
 .venv
-*.pyc
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+*.whl
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# Zephyr blobs (local builds)
+zephyr/blobs/lib/
 
 **/.cdk
 **/Lst


### PR DESCRIPTION
Add common ignore patterns for Python bytecode and packaging files, macOS metadata files, and local blob build artifacts under `zephyr/blobs/lib/`.