### PR TITLE
ci: add workflow to verify blob URLs and SHA256 checksums

### DIFF
--- a/.github/workflows/verify-blobs.yml
+++ b/.github/workflows/verify-blobs.yml
@@ -1,0 +1,36 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Verify Blobs
+
+on:
+  push:
+    paths:
+      - 'zephyr/module.yml'
+      - '.github/workflows/verify-blobs.yml'
+  pull_request:
+    paths:
+      - 'zephyr/module.yml'
+      - '.github/workflows/verify-blobs.yml'
+  workflow_dispatch:
+
+jobs:
+  verify-blobs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install west
+        run: pip install west
+
+      - name: Initialize west workspace
+        run: west init -m https://github.com/zephyrproject-rtos/zephyr --mr main
+
+      - name: Clone Zephyr (shallow)
+        run: west update --narrow --fetch-opt=--depth=1 zephyr
+
+      - name: Checkout hal_bouffalolab under test
+        uses: actions/checkout@v4
+        with:
+          path: modules/hal/bouffalolab
+
+      - name: Fetch and verify blobs
+        run: west blobs fetch hal_bouffalolab


### PR DESCRIPTION
Add a GitHub Actions workflow that downloads each blob defined in zephyr/module.yml and verifies URL reachability and SHA256 integrity. Runs weekly (Monday 08:00 UTC), on module.yml or CI file changes, and via manual dispatch.