### PR TITLE
bflb: add BL602 WiFi firmware blob and driver headers

### DIFF
--- a/include/bouffalolab/bl60x/wifi/bl60x_fw_api.h
+++ b/include/bouffalolab/bl60x/wifi/bl60x_fw_api.h
@@ -1,0 +1,605 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef BL60X_FW_API_H_
+#define BL60X_FW_API_H_
+
+
+/* Tasks types. */
+typedef enum wifi_fw_task_id
+{
+    TASK_NONE = (uint8_t) -1,
+
+    /* MAC Management task. */
+    TASK_MM = 0,
+    /* SCAN task */
+    TASK_SCAN,
+    /* SCAN task */
+    TASK_SCANU,
+    /* SCAN task */
+    TASK_ME,
+    /* SM task */
+    TASK_SM,
+    /* APM task */
+    TASK_APM,
+    /* BAM task */
+    TASK_BAM,
+    /* RXU task */
+    TASK_RXU,
+
+    TASK_CFG,
+
+    /* This is used to define the last task that is running on the EMB processor */
+    TASK_LAST_EMB = TASK_CFG,
+
+    /* nX API task */
+    TASK_API,
+    TASK_MAX,
+} ke_task_id_t;
+
+/* For MAC HW States. */
+typedef enum hw_state_tag
+{
+    /* MAC HW IDLE State. */
+    HW_IDLE = 0,
+    /* MAC HW RESERVED State. */
+    HW_RESERVED,
+    /* MAC HW DOZE State. */
+    HW_DOZE,
+    /* MAC HW ACTIVE State. */
+    HW_ACTIVE
+} hw_state_tag_t;
+
+/* Possible States of the MM STA Task. */
+typedef enum mm_state_tag
+{
+    /* MAC IDLE State. */
+    MM_IDLE,
+    /* MAC ACTIVE State. */
+    MM_ACTIVE,
+    /* MAC is going to IDLE */
+    MM_GOING_TO_IDLE,
+    /* IDLE state internally controlled */
+    MM_HOST_BYPASSED,
+    /* MAC Max Number of states. */
+    MM_STATE_MAX
+} mm_state_tag_t;
+
+/**
+ ****************************************************************************************
+ * @brief Builds the first message ID of a task
+ * @param[in] task Task identifier
+ * @return The identifier of the first message of the task
+ ****************************************************************************************
+ */
+#define KE_FIRST_MSG(task) (((task) << 10))
+
+/* Message Identifier. The number of messages is limited to 0xFFFF. */
+/* The message ID is divided in two parts: */
+/* bits[15~8]: task index (no more than 255 tasks support) */
+/* bits[7~0]: message index(no more than 255 messages per task) */
+typedef enum wifi_fw_event_id
+{
+    /* RESET Request. */
+    MM_RESET_REQ = KE_FIRST_MSG(TASK_MM),
+    /* RESET Confirmation. */
+    MM_RESET_CFM,
+    /* START Request. */
+    MM_START_REQ,
+    /* START Confirmation. */
+    MM_START_CFM,
+    /* Read Version Request. */
+    MM_VERSION_REQ,
+    /* Read Version Confirmation. */
+    MM_VERSION_CFM,
+    /* ADD INTERFACE Request. */
+    MM_ADD_IF_REQ,
+    /* ADD INTERFACE Confirmation. */
+    MM_ADD_IF_CFM,
+    /* REMOVE INTERFACE Request. */
+    MM_REMOVE_IF_REQ,
+    /* REMOVE INTERFACE Confirmation. */
+    MM_REMOVE_IF_CFM,
+    /* STA ADD Request. */
+    MM_STA_ADD_REQ,
+    /* STA ADD Confirm. */
+    MM_STA_ADD_CFM,
+    /* STA DEL Request. */
+    MM_STA_DEL_REQ,
+    /* STA DEL Confirm. */
+    MM_STA_DEL_CFM,
+    /* CHANNEL CONFIGURATION Request. */
+    MM_SET_CHANNEL_REQ,
+    /* CHANNEL CONFIGURATION Confirmation. */
+    MM_SET_CHANNEL_CFM,
+    /* BEACON INTERVAL CONFIGURATION Request. */
+    MM_SET_BEACON_INT_REQ,
+    /* BEACON INTERVAL CONFIGURATION Confirmation. */
+    MM_SET_BEACON_INT_CFM,
+    /* BASIC RATES CONFIGURATION Request. */
+    MM_SET_BASIC_RATES_REQ,
+    /* BASIC RATES CONFIGURATION Confirmation. */
+    MM_SET_BASIC_RATES_CFM,
+    /* BSSID CONFIGURATION Request. */
+    MM_SET_BSSID_REQ,
+    /* BSSID CONFIGURATION Confirmation. */
+    MM_SET_BSSID_CFM,
+    /* EDCA PARAMETERS CONFIGURATION Request. */
+    MM_SET_EDCA_REQ,
+    /* EDCA PARAMETERS CONFIGURATION Confirmation. */
+    MM_SET_EDCA_CFM,
+    /* Request setting the VIF active state (i.e associated or AP started) */
+    MM_SET_VIF_STATE_REQ,
+    /* Confirmation of the @ref MM_SET_VIF_STATE_REQ message. */
+    MM_SET_VIF_STATE_CFM,
+    /* IDLE mode change Request. */
+    MM_SET_IDLE_REQ,
+    /* IDLE mode change Confirm. */
+    MM_SET_IDLE_CFM,
+    /* Indication of the primary TBTT to the upper MAC. Upon the reception of this */
+    /* message the upper MAC has to push the beacon(s) to the beacon transmission queue. */
+    MM_PRIMARY_TBTT_IND,
+    /* Indication of the secondary TBTT to the upper MAC. Upon the reception of this */
+    /* message the upper MAC has to push the beacon(s) to the beacon transmission queue. */
+    MM_SECONDARY_TBTT_IND,
+    /* Request to the LMAC to trigger the embedded logic analyzer and forward the debug */
+    /* dump. */
+    MM_DENOISE_REQ,
+    /* Set Power Save mode */
+    MM_SET_PS_MODE_REQ,
+    /* set power save mode off for internal fw */
+    MM_SET_PS_OFF_INTERNAL_REQ,
+    /* Set Power Save mode confirmation */
+    MM_SET_PS_MODE_CFM,
+    /* Request to add a channel context */
+    MM_CHAN_CTXT_ADD_REQ,
+    /* Confirmation of the channel context addition */
+    MM_CHAN_CTXT_ADD_CFM,
+    /* Request to delete a channel context */
+    MM_CHAN_CTXT_DEL_REQ,
+    /* Confirmation of the channel context deletion */
+    MM_CHAN_CTXT_DEL_CFM,
+    /* Request to link a channel context to a VIF */
+    MM_CHAN_CTXT_LINK_REQ,
+    /* Confirmation of the channel context link */
+    MM_CHAN_CTXT_LINK_CFM,
+    /* Request to unlink a channel context from a VIF */
+    MM_CHAN_CTXT_UNLINK_REQ,
+    /* Confirmation of the channel context unlink */
+    MM_CHAN_CTXT_UNLINK_CFM,
+    /* Request to update a channel context */
+    MM_CHAN_CTXT_UPDATE_REQ,
+    /* Confirmation of the channel context update */
+    MM_CHAN_CTXT_UPDATE_CFM,
+    /* Request to schedule a channel context */
+    MM_CHAN_CTXT_SCHED_REQ,
+    /* Confirmation of the channel context scheduling */
+    MM_CHAN_CTXT_SCHED_CFM,
+    /* Request to change the beacon template in LMAC */
+    MM_BCN_CHANGE_REQ,
+    /* Confirmation of the beacon change */
+    MM_BCN_CHANGE_CFM,
+    /* Request to update the TIM in the beacon (i.e to indicate traffic bufferized at AP) */
+    MM_TIM_UPDATE_REQ,
+    /* Confirmation of the TIM update */
+    MM_TIM_UPDATE_CFM,
+    /* Connection loss indication */
+    MM_CONNECTION_LOSS_IND,
+    /* Channel context switch indication to the upper layers */
+    MM_CHANNEL_SWITCH_IND,
+    /* Channel context pre-switch indication to the upper layers */
+    MM_CHANNEL_PRE_SWITCH_IND,
+    /* Request to remain on channel or cancel remain on channel */
+    MM_REMAIN_ON_CHANNEL_REQ,
+    /* Confirmation of the (cancel) remain on channel request */
+    MM_REMAIN_ON_CHANNEL_CFM,
+    /* Remain on channel expired indication */
+    MM_REMAIN_ON_CHANNEL_EXP_IND,
+    /* Indication of a PS state change of a peer device */
+    MM_PS_CHANGE_IND,
+    /* Indication that some buffered traffic should be sent to the peer device */
+    MM_TRAFFIC_REQ_IND,
+    /* Request to modify the STA Power-save mode options */
+    MM_SET_PS_OPTIONS_REQ,
+    /* Confirmation of the PS options setting */
+    MM_SET_PS_OPTIONS_CFM,
+    /* Indication of PS state change for a P2P VIF */
+    MM_P2P_VIF_PS_CHANGE_IND,
+    /* Indication that CSA counter has been updated */
+    MM_CSA_COUNTER_IND,
+    /* Message containing channel information */
+    MM_CHANNEL_SURVEY_IND,
+    /* Message containing Beamformer information */
+    MM_BFMER_ENABLE_REQ,
+    /* Request to Start/Stop NOA - GO Only */
+    MM_SET_P2P_NOA_REQ,
+    /* Request to Start/Stop Opportunistic PS - GO Only */
+    MM_SET_P2P_OPPPS_REQ,
+    /* Start/Stop NOA Confirmation */
+    MM_SET_P2P_NOA_CFM,
+    /* Start/Stop Opportunistic PS Confirmation */
+    MM_SET_P2P_OPPPS_CFM,
+    /* P2P NoA Update Indication - GO Only */
+    MM_P2P_NOA_UPD_IND,
+    /* Indication that RSSI is below or above the threshold */
+    MM_RSSI_STATUS_IND,
+    /* Indication that CSA is done */
+    MM_CSA_FINISH_IND,
+    /* Indication that CSA is in prorgess (resp. done) and traffic must be stopped (resp. restarted) */
+    MM_CSA_TRAFFIC_IND,
+    /* Request to update the group information of a station */
+    MM_MU_GROUP_UPDATE_REQ,
+    /* Confirmation of the @ref MM_MU_GROUP_UPDATE_REQ message */
+    MM_MU_GROUP_UPDATE_CFM,
+    /* Enable monitor mode */
+    MM_MONITOR_REQ,
+    MM_MONITOR_CFM,
+    /* Channel set under monitor mode */
+    MM_MONITOR_CHANNEL_REQ,
+    MM_MONITOR_CHANNEL_CFM,
+
+    /*
+     * Section of internal MM messages. No MM API messages should be defined below this point
+     */
+    /* Internal request to force the HW going to IDLE */
+    MM_FORCE_IDLE_REQ,
+    /* Message indicating that the switch to the scan channel is done */
+    MM_SCAN_CHANNEL_START_IND,
+    /* Message indicating that the scan can end early */
+    MM_SCAN_CHANNEL_END_EARLY,
+    /* Message indicating that the scan on the channel is finished */
+    MM_SCAN_CHANNEL_END_IND,
+
+    /* MAX number of messages */
+    MM_MAX,
+
+    /* Request to start the AP. */
+    CFG_START_REQ = KE_FIRST_MSG(TASK_CFG),
+    CFG_START_CFM,
+    CFG_MAX,
+
+
+    /* Scanning start Request. */
+    SCAN_START_REQ = KE_FIRST_MSG(TASK_SCAN),
+    /* Scanning start Confirmation. */
+    SCAN_START_CFM,
+    /* End of scanning indication. */
+    SCAN_DONE_IND,
+    /* Cancel scan request */
+    SCAN_CANCEL_REQ,
+    /* Cancel scan confirmation */
+    SCAN_CANCEL_CFM,
+
+    /* Abort scan request */
+    SCAN_ABORT_REQ,
+    SCAN_ABORT_CFM,
+
+    /*
+     * Section of internal SCAN messages. No SCAN API messages should be defined below this point
+     */
+    SCAN_PROBE_TIMER,
+
+    /* MAX number of messages */
+    SCAN_MAX,
+
+    /* Request to start the AP. */
+    APM_START_REQ = KE_FIRST_MSG(TASK_APM),
+    /* Confirmation of the AP start. */
+    APM_START_CFM,
+    /* Request to stop the AP. */
+    APM_STOP_REQ,
+    /* Confirmation of the AP stop. */
+    APM_STOP_CFM,
+    /* Nofity host that a station has joined the network */
+    APM_STA_ADD_IND,
+    /* Nofity host that a station has left the network */
+    APM_STA_DEL_IND,
+    /* Check sta connect timeout */
+    APM_STA_CONNECT_TIMEOUT_IND,
+    /* Request to delete STA */
+    APM_STA_DEL_REQ,
+    /* Confirmation of delete STA */
+    APM_STA_DEL_CFM,
+    /* CONF MAX STA Request */
+    APM_CONF_MAX_STA_REQ,
+    /* CONF MAX STA Confirm */
+    APM_CONF_MAX_STA_CFM,
+    /* Channel switch Request */
+    APM_CHAN_SWITCH_REQ,
+    /* Channel switch Confirm */
+    APM_CHAN_SWITCH_CFM,
+    /* MAX number of messages */
+    APM_MAX,
+
+    /* BAM addition response timeout */
+    BAM_ADD_BA_RSP_TIMEOUT_IND  = KE_FIRST_MSG(TASK_BAM),
+    /* BAM Inactivity timeout */
+    BAM_INACTIVITY_TIMEOUT_IND,
+
+    /* Configuration request from host. */
+    ME_CONFIG_REQ = KE_FIRST_MSG(TASK_ME),
+    /* Configuration confirmation. */
+    ME_CONFIG_CFM,
+    /* Configuration request from host. */
+    ME_CHAN_CONFIG_REQ,
+    /* Configuration confirmation. */
+    ME_CHAN_CONFIG_CFM,
+    /* TKIP MIC failure indication. */
+    ME_TKIP_MIC_FAILURE_IND,
+    /* Add a station to the FW (AP mode) */
+    ME_STA_ADD_REQ,
+    /* Confirmation of the STA addition */
+    ME_STA_ADD_CFM,
+    /* Delete a station from the FW (AP mode) */
+    ME_STA_DEL_REQ,
+    /* Confirmation of the STA deletion */
+    ME_STA_DEL_CFM,
+    /* Indication of a TX RA/TID queue credit update */
+    ME_TX_CREDITS_UPDATE_IND,
+    /* Request indicating to the FW that there is traffic buffered on host */
+    ME_TRAFFIC_IND_REQ,
+    /* Confirmation that the @ref ME_TRAFFIC_IND_REQ has been executed */
+    ME_TRAFFIC_IND_CFM,
+    /* Request RC fixed rate */
+    ME_RC_SET_RATE_REQ,
+
+    /*
+     * Section of internal ME messages. No ME API messages should be defined below this point
+     */
+    /* Internal request to indicate that a VIF needs to get the HW going to ACTIVE or IDLE */
+    ME_SET_ACTIVE_REQ,
+    /* Confirmation that the switch to ACTIVE or IDLE has been executed */
+    ME_SET_ACTIVE_CFM,
+    /* Internal request to indicate that a VIF desires to de-activate/activate the Power-Save mode */
+    ME_SET_PS_DISABLE_REQ,
+    /* Confirmation that the PS state de-activate/activate has been executed */
+    ME_SET_PS_DISABLE_CFM,
+    /* MAX number of messages */
+    ME_MAX,
+
+    /* Management frame reception indication */
+    RXU_MGT_IND = KE_FIRST_MSG(TASK_RXU),
+    /* NULL frame reception indication */
+    RXU_NULL_DATA,
+
+    /* Scan request from host. */
+    SCANU_START_REQ = KE_FIRST_MSG(TASK_SCANU),
+    /* Scanning start Confirmation. */
+    SCANU_START_CFM,
+    /* Join request */
+    SCANU_JOIN_REQ,
+    /* Join confirmation. */
+    SCANU_JOIN_CFM,
+    /* Scan result indication. */
+    SCANU_RESULT_IND,
+    /* Scan RAW Data Send from host */
+    SCANU_RAW_SEND_REQ,
+    /* Scan result indication. */
+    SCANU_RAW_SEND_CFM,
+
+    /* MAX number of messages */
+    SCANU_MAX,
+
+    /* Request to connect to an AP */
+    SM_CONNECT_REQ = KE_FIRST_MSG(TASK_SM),
+    /* Confirmation of connection */
+    SM_CONNECT_CFM,
+    /* Indicates that the SM associated to the AP */
+    SM_CONNECT_IND,
+    /* Request to disconnect */
+    SM_DISCONNECT_REQ,
+    /* Confirmation of disconnection */
+    SM_DISCONNECT_CFM,
+    /* Indicates that the SM disassociated the AP */
+    SM_DISCONNECT_IND,
+    /* Timeout message for procedures requiring a response from peer */
+    SM_RSP_TIMEOUT_IND,
+    /* Request to cancel connect when connecting */
+    SM_CONNECT_ABORT_REQ,
+    /* Confirmation of connect abort */
+    SM_CONNECT_ABORT_CFM,
+    /* Timeout message for requiring a SA Query Response from AP */
+    SM_SA_QUERY_TIMEOUT_IND,
+    /* Indicates add AP info */
+    SM_STA_ADD_IND,
+    /* Request for send pending auth or assoc */
+    SM_CONNECT_AUTH_ASSOC_REQ,
+    /* Request for auth_start */
+    SM_CONNECT_AUTH_START,
+    /* MAX number of messages */
+    SM_MAX,
+} ke_msg_id_t;
+
+/*--------------------------------------------------------------------*/
+/* Status Codes - these codes are used in bouffalolab fw actions      */
+/* when an error action is taking place the status code can indicate  */
+/* what the status code.                                              */
+/* It is defined by bouffaloalb                                       */
+/*--------------------------------------------------------------------*/
+#define WLAN_FW_SUCCESSFUL                                        0
+#define WLAN_FW_TX_AUTH_FRAME_ALLOCATE_FAIILURE                   1
+#define WLAN_FW_AUTHENTICATION_FAIILURE                           2
+#define WLAN_FW_AUTH_ALGO_FAIILURE                                3
+#define WLAN_FW_TX_ASSOC_FRAME_ALLOCATE_FAIILURE                  4
+#define WLAN_FW_ASSOCIATE_FAIILURE                                5
+#define WLAN_FW_DEAUTH_BY_AP_WHEN_NOT_CONNECTION                  6
+#define WLAN_FW_DEAUTH_BY_AP_WHEN_CONNECTION                      7
+#define WLAN_FW_4WAY_HANDSHAKE_ERROR_PSK_TIMEOUT_FAILURE          8
+#define WLAN_FW_4WAY_HANDSHAKE_TX_DEAUTH_FRAME_TRANSMIT_FAILURE   9
+#define WLAN_FW_4WAY_HANDSHAKE_TX_DEAUTH_FRAME_ALLOCATE_FAIILURE 10
+#define WLAN_FW_AUTH_OR_ASSOC_RESPONSE_TIMEOUT_FAILURE           11
+#define WLAN_FW_SCAN_NO_BSSID_AND_CHANNEL                        12
+#define WLAN_FW_CREATE_CHANNEL_CTX_FAILURE_WHEN_JOIN_NETWORK     13
+#define WLAN_FW_JOIN_NETWORK_FAILURE                             14
+#define WLAN_FW_ADD_STA_FAILURE                                  15
+#define WLAN_FW_BEACON_LOSS                                      16
+#define WLAN_FW_JOIN_NETWORK_SECURITY_NOMATCH                    17
+#define WLAN_FW_JOIN_NETWORK_WEPLEN_ERROR                        18
+#define WLAN_FW_DISCONNECT_BY_USER_WITH_DEAUTH                   19
+#define WLAN_FW_DISCONNECT_BY_USER_NO_DEAUTH                     20
+#define WLAN_FW_DISCONNECT_BY_FW_PS_TX_NULLFRAME_FAILURE         21
+#define WLAN_FW_TRAFFIC_LOSS                                     22
+#define WLAN_FW_CONNECT_ABORT_BY_USER_WITH_DEAUTH                23
+#define WLAN_FW_CONNECT_ABORT_BY_USER_NO_DEAUTH                  24
+#define WLAN_FW_CONNECT_ABORT_WHEN_JOINING_NETWORK               25
+#define WLAN_FW_CONNECT_ABORT_WHEN_SCANNING                      26
+
+
+/*--------------------------------------------------------------------*/
+/* AP Mode Status Codes - these codes are used in bouffalolab fw actions      */
+/* when an error action is taking place the status code can indicate  */
+/* what the status code.                                              */
+/* It is defined by bouffaloalb                                       */
+/*--------------------------------------------------------------------*/
+#define WLAN_FW_APM_SUCCESSFUL                                        0
+#define WLAN_FW_APM_DELETESTA_BY_USER                                 1
+#define WLAN_FW_APM_DEATUH_BY_STA                                     2
+#define WLAN_FW_APM_DISASSOCIATE_BY_STA                               3
+#define WLAN_FW_APM_DELETECONNECTION_TIMEOUT                          4
+#define WLAN_FW_APM_DELETESTA_FOR_NEW_CONNECTION                      5
+#define WLAN_FW_APM_DEAUTH_BY_AUTHENTICATOR                           6
+
+void bl60x_fw_xtal_capcode_set(uint8_t cap_in, uint8_t cap_out, uint8_t enable, uint8_t cap_in_max, uint8_t cap_out_max);
+void bl60x_fw_xtal_capcode_update(uint8_t cap_in, uint8_t cap_out);
+void bl60x_fw_xtal_capcode_restore(void);
+void bl60x_fw_xtal_capcode_autofit(void);
+void bl60x_fw_xtal_capcode_get(uint8_t *cap_in, uint8_t *cap_out);
+int bl60x_fw_password_hash(char *password, char *ssid, int ssidlength, char *output);
+void bl60x_fw_rf_table_set(uint32_t* channel_div_table_in, uint16_t* channel_cnt_table_in,
+                                                uint16_t lo_fcal_div);
+
+void bl60x_fw_dump_data(void);
+void bl60x_fw_dump_statistic(int forced);
+
+int bl60x_check_mac_status(int *is_ok);
+
+enum {
+    /* Background */
+    API_AC_BK = 0,
+    /* Best-effort */
+    API_AC_BE,
+    /* Video */
+    API_AC_VI,
+    /* Voice */
+    API_AC_VO,
+    /* Number of access categories */
+    API_AC_MAX
+};
+
+int bl60x_edca_get(int ac, uint8_t *aifs, uint8_t *cwmin, uint8_t *cwmax, uint16_t *txop);
+
+/*Wi-Fi Firmware Entry*/
+void wifi_main(void *param);
+
+void bl_tpc_update_power_table(int8_t power_table_config[38]);
+void bl_tpc_update_power_table_rate(int8_t power_table[24]);
+void bl_tpc_update_power_table_channel_offset(int8_t power_table[14]);
+void bl_tpc_update_power_rate_11b(int8_t power_rate_table[4]);
+void bl_tpc_update_power_rate_11g(int8_t power_rate_table[8]);
+void bl_tpc_update_power_rate_11n(int8_t power_rate_table[8]);
+void bl_tpc_power_table_get(int8_t power_table_config[38]);
+
+void phy_cli_register(void);
+
+
+
+enum task_mm_cfg {
+    TASK_MM_CFG_KEEP_ALIVE_STATUS_ENABLED,
+    TASK_MM_CFG_KEEP_ALIVE_TIME_LAST_RECEIVED,
+    TASK_MM_CFG_KEEP_ALIVE_PACKET_COUNTER,
+    TASK_MM_CFG_ACCEPT_ALL_BEACON_FOR_STA,
+    TASK_MM_CFG_ACCEPT_ALL_BEACON_FOR_AP,
+    TASK_MM_CFG_BEACON_TIMEOUT,
+    TASK_MM_CFG_PSM_TBTT_PRE,
+    TASK_MM_CFG_PS_TX_TIMEOUT,
+};
+
+enum task_sm_cfg {
+    TASK_SM_CFG_AUTH_ASSOC_RETRY_LIMIT,
+    TASK_SM_CFG_RECONNECT_TRIGGER_FLAG,
+    TASK_SM_CFG_AUTH_START_DELAY,
+};
+
+enum task_scan_cfg {
+    TASK_SCAN_CFG_DURATION_SCAN_PASSIVE,
+    TASK_SCAN_CFG_DURATION_SCAN_ACTIVE,
+    TASK_SCAN_CFG_DURATION_SCAN_JOIN_ACTIVE,
+};
+
+typedef enum{
+    /**version part**/
+    SM_CONNECTION_DATA_TLV_ID_VERSION,
+    /**Status part**/
+    SM_CONNECTION_DATA_TLV_ID_STATUS_CODE,
+    SM_CONNECTION_DATA_TLV_ID_DHCPSTATUS,
+    /**frame part**/
+    SM_CONNECTION_DATA_TLV_ID_AUTH_1,
+    SM_CONNECTION_DATA_TLV_ID_AUTH_2,
+    SM_CONNECTION_DATA_TLV_ID_AUTH_3,
+    SM_CONNECTION_DATA_TLV_ID_AUTH_4,
+    SM_CONNECTION_DATA_TLV_ID_ASSOC_REQ,
+    SM_CONNECTION_DATA_TLV_ID_ASSOC_RSP,
+    SM_CONNECTION_DATA_TLV_ID_4WAY_1,
+    SM_CONNECTION_DATA_TLV_ID_4WAY_2,
+    SM_CONNECTION_DATA_TLV_ID_4WAY_3,
+    SM_CONNECTION_DATA_TLV_ID_4WAY_4,
+    SM_CONNECTION_DATA_TLV_ID_2WAY_1,
+    SM_CONNECTION_DATA_TLV_ID_2WAY_2,
+    SM_CONNECTION_DATA_TLV_ID_DEAUTH,
+    /**striped frame part**/
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_AUTH_1,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_AUTH_2,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_AUTH_3,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_AUTH_4,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_AUTH_UNVALID,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_ASSOC_REQ,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_ASSOC_RSP,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_DEAUTH_FROM_REMOTE,
+    SM_CONNECTION_DATA_TLV_ID_STRIPED_DEASSOC_FROM_REMOTE,
+    SM_CONNECTION_DATA_TLV_ID_RESERVED,
+} sm_connection_data_tlv_id_t;
+
+/* structure of a list element header */
+struct sm_tlv_list_hdr
+{
+    struct sm_tlv_list_hdr *next;
+};
+
+/* structure of a list */
+struct sm_tlv_list
+{
+    struct sm_tlv_list_hdr *first;
+    struct sm_tlv_list_hdr *last;
+};
+
+/*
+ * TLV ID数据以链表的形式存储在struct sm_connect_tlv_desc中，
+ * callback需要遍历这个链表来获取所有的数据
+ */
+struct sm_connect_tlv_desc {
+    struct sm_tlv_list_hdr list_hdr;
+    sm_connection_data_tlv_id_t id;
+    uint16_t len;
+    uint8_t data[0];
+};
+
+#ifdef TD_DIAGNOSIS_STA
+typedef struct wifi_diagnosis_info
+{
+    uint32_t beacon_recv;
+    uint32_t beacon_loss;
+    uint32_t beacon_total;
+    uint64_t unicast_recv;
+    uint64_t unicast_send;
+    uint64_t multicast_recv;
+    uint64_t multicast_send;
+}wifi_diagnosis_info_t;
+
+wifi_diagnosis_info_t *bl_diagnosis_get(void);
+int wifi_td_diagnosis_init(void);
+int wifi_td_diagnosis_deinit(void);
+#endif
+
+#endif /* BL60X_FW_API_H_ */

--- a/include/bouffalolab/bl60x/wifi/ipc_compat.h
+++ b/include/bouffalolab/bl60x/wifi/ipc_compat.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ ****************************************************************************************
+ *
+ * @file ipc_compat.h
+ * Copyright (C) Bouffalo Lab 2016-2018
+ *
+ ****************************************************************************************
+ */
+
+
+#ifndef IPC_COMPAT_H_
+#define IPC_COMPAT_H_
+
+
+/* Zephyr's <zephyr/toolchain/gcc.h> defines __WARN(msg) too — undef the
+ * Zephyr definition first so the vendor-style argless __WARN() works here.
+ * The vendor IPC code only uses the no-arg form. */
+#ifdef __WARN
+#undef __WARN
+#endif
+#define __WARN()        bflb_os_printf("%s:%d\r\n", __func__, __LINE__)
+
+#define WARN_ON(condition) ({                       \
+    int __ret_warn_on = !!(condition);              \
+    if (__ret_warn_on)                              \
+        __WARN();                                   \
+    __ret_warn_on;                                  \
+    })
+
+#define WARN_ON_ONCE(condition) ({          \
+    static bool __warned;                   \
+    int __ret_warn_once = !!(condition);    \
+                                            \
+    if (__ret_warn_once)                    \
+        if (WARN_ON(!__warned))             \
+            __warned = true;                \
+    __ret_warn_once;                        \
+    })
+
+#define __round_mask(x, y) ((__typeof__(x))((y)-1))
+#define round_up(x, y) ((((x)-1) | __round_mask(x, y))+1)
+#define round_down(x, y) ((x) & ~__round_mask(x, y))
+
+#define ASSERT_ERR(condition)   assert(condition)
+
+#endif /* IPC_COMPAT_H_ */

--- a/include/bouffalolab/bl60x/wifi/ipc_shared.h
+++ b/include/bouffalolab/bl60x/wifi/ipc_shared.h
@@ -1,0 +1,301 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ ****************************************************************************************
+ *
+ * @file ipc_shared.h
+ * Copyright (C) Bouffalo Lab 2016-2018
+ *
+ ****************************************************************************************
+ */
+
+
+#ifndef IPC_SHARED_H_
+#define IPC_SHARED_H_
+
+/*
+ * INCLUDE FILES
+ ****************************************************************************************
+ */
+
+/*
+ * DEFINES AND MACROS
+ ****************************************************************************************
+ */
+#define CO_BIT(pos) (1U<<(pos))
+#define NX_TXQ_CNT          4
+#define CONFIG_USER_MAX     1
+
+
+#ifndef CFG_TXDESC
+#define CFG_TXDESC          4
+#endif
+#ifndef CFG_VIRT_DEV_MAX
+#define CFG_VIRT_DEV_MAX    2
+#endif
+#ifndef CFG_STA_MAX
+#define CFG_STA_MAX         5
+#endif
+#ifndef CFG_CHIP_BL602
+#define CFG_CHIP_BL602      1
+#endif
+
+#define IPC_TXQUEUE_CNT     NX_TXQ_CNT
+#define NX_TXDESC_CNT0      CFG_TXDESC
+#define NX_TXDESC_CNT1      CFG_TXDESC
+#define NX_TXDESC_CNT2      CFG_TXDESC
+#define NX_TXDESC_CNT3      CFG_TXDESC
+#define NX_TXDESC_CNT4      CFG_TXDESC
+/*
+ * Number of Host buffers available for Data Rx handling (through DMA)
+ */
+#define IPC_RXBUF_CNT       2
+
+/*
+ * Number of shared descriptors available for Data RX handling
+ */
+#define IPC_RXDESC_CNT      2
+
+/*
+ * Number of Host buffers available for Radar events handling (through DMA)
+ */
+#define IPC_RADARBUF_CNT       4
+
+/*
+ * RX Data buffers size (in bytes)
+ */
+#define IPC_RXBUF_SIZE 2048
+
+/*
+ * Number of Host buffers available for Emb->App MSGs sending (through DMA)
+ */
+#define IPC_MSGE2A_BUF_CNT       8
+
+/*
+ * Number of Host buffers available for Debug Messages sending (through DMA)
+ */
+#define IPC_DBGBUF_CNT       4
+
+/*
+ * Length used in MSGs structures
+ */
+#define IPC_A2E_MSG_BUF_SIZE    127 /* size in 4-byte words */
+#define IPC_E2A_MSG_PARAM_SIZE   (257 - 4 - 8) /* size in 4-byte words */
+/*
+ * Debug messages buffers size (in bytes)
+ */
+#define IPC_DBG_PARAM_SIZE       256
+
+/*
+ * Define used for Rx hostbuf validity.
+ * This value should appear only when hostbuf was used for a Reception.
+ */
+#define RX_DMA_OVER_PATTERN 0xAAAAAA00
+
+/*
+ * Define used for MSG buffers validity.
+ * This value will be written only when a MSG buffer is used for sending from Emb to App.
+ */
+#define IPC_MSGE2A_VALID_PATTERN 0xADDEDE2A
+
+/*
+ * Define used for Debug messages buffers validity.
+ * This value will be written only when a DBG buffer is used for sending from Emb to App.
+ */
+#define IPC_DBG_VALID_PATTERN 0x000CACA0
+
+/*
+ *  Length of the receive vectors, in bytes
+ */
+#define DMA_HDR_PHYVECT_LEN    36
+
+/*
+ * Maximum number of payload addresses and lengths present in the descriptor
+ */
+#define NX_TX_PAYLOAD_MAX      6
+
+/*
+ ****************************************************************************************
+ */
+/* c.f LMAC/src/tx/tx_swdesc.h */
+/* Descriptor filled by the Host */
+struct hostdesc
+{
+    /* allocated pbuf */
+    uint32_t pbuf_addr;
+    /* Pointer to packet payload */
+    uint32_t packet_addr;
+    /* Size of the payload */
+    uint16_t packet_len;
+
+    /* Address of the status descriptor in host memory (used for confirmation upload) */
+    uint32_t status_addr;
+    /* Destination Address */
+    struct mac_addr eth_dest_addr;
+    /* Source Address */
+    struct mac_addr eth_src_addr;
+    /* Ethernet Type */
+    uint16_t ethertype;
+    /* Buffer containing the PN to be used for this packet */
+    uint16_t pn[4];
+    /* Sequence Number used for transmission of this MPDU */
+    uint16_t sn;
+    /* Timestamp of first transmission of this MPDU */
+    uint16_t timestamp;
+    /* Packet TID (0xFF if not a QoS frame) */
+    uint8_t tid;
+    /* Interface Id */
+    uint8_t vif_idx;
+    /* VIF type */
+    uint8_t vif_type; /* 0: STA, 1: AP, [2-FF]:Other */
+    /* Station Id (0xFF if station is unknown) */
+    uint8_t staid;
+    /* TX flags */
+    uint16_t flags;
+    uint32_t pbuf_chained_ptr[4]; /* max 4 chained pbuf for one output ethernet packet */
+    uint32_t pbuf_chained_len[4]; /* max 4 chained pbuf for one output ethernet packet */
+    /* Time when TX desc is postponed */
+    uint32_t postpone_time;
+};
+
+/* structure of a list element header */
+struct co_list_hdr
+{
+    /* Pointer to the next element in the list */
+    struct co_list_hdr *next;
+};
+
+/* structure of a list */
+struct co_list
+{
+    /* pointer to first element of the list */
+    struct co_list_hdr *first;
+    /* pointer to the last element */
+    struct co_list_hdr *last;
+};
+
+/* upper part of struct txdesc */
+struct txdesc_upper
+{
+    /* Pointer to the next element in the queue */
+    struct co_list_hdr list_hdr;
+    /* Information provided by Host */
+    struct hostdesc host;
+};
+
+struct txdesc_host
+{
+    struct utils_list_hdr list_hdr;
+
+    void *host_id;
+
+    uint32_t ready;
+
+    uint32_t pad_txdesc[208/4];
+
+    uint32_t pad_buf[400/4];
+};
+
+/* Structure containing the information about the PHY channel that is used */
+struct phy_channel_info
+{
+    /* PHY channel information 1 */
+    uint32_t info1;
+    /* PHY channel information 2 */
+    uint32_t info2;
+};
+
+/**
+ ****************************************************************************************
+ *  @defgroup IPC_MISC IPC Misc
+ *  @ingroup IPC
+ *  @brief IPC miscellaneous functions
+ ****************************************************************************************
+ */
+/* Message structure for MSGs from Emb to App. */
+/* Use explicit-size types so layout matches the blob (which is built with */
+/* -fshort-enums, where ke_msg_id_t is uint16_t and ke_task_id_t is uint8_t) */
+/* regardless of whether THIS file's caller uses -fshort-enums or not. */
+struct ipc_e2a_msg
+{
+    uint16_t id; /* Message id (was ke_msg_id_t). */
+    uint8_t  dummy_dest_id; /* (was ke_task_id_t) */
+    uint8_t  dummy_src_id; /* (was ke_task_id_t) */
+    uint32_t param_len; /* Parameter embedded struct length. */
+    uint32_t param[IPC_E2A_MSG_PARAM_SIZE]; /* Parameter embedded struct. Word-aligned. */
+    uint32_t pattern; /* Used to stamp a valid MSG buffer */
+};
+
+/* Message structure for MSGs from App to Emb. */
+/* Actually a sub-structure will be used when filling the messages. */
+struct ipc_a2e_msg
+{
+    uint32_t dummy_word; /* used to cope with kernel message structure */
+    uint32_t msg[IPC_A2E_MSG_BUF_SIZE]; /* body of the msg */
+};
+
+/* Indexes are defined in the MIB shared structure */
+
+struct ipc_shared_env_tag
+{
+    volatile struct ipc_a2e_msg msg_a2e_buf; /* room for MSG to be sent from App to Emb */
+
+    /* Host buffer address for the TX payload descriptor pattern */
+    volatile uint32_t  pattern_addr;
+
+    /* Array of TX descriptors for the BK queue */
+    volatile struct txdesc_host txdesc0[NX_TXDESC_CNT0];
+
+    /* List of free txdesc */
+    struct utils_list list_free;
+    /* List of ongoing txdesc */
+    struct utils_list list_ongoing;
+    /* List of cfm txdesc */
+    struct utils_list list_cfm;
+};
+
+extern struct ipc_shared_env_tag ipc_shared_env;
+
+
+/*
+ * TYPE and STRUCT DEFINITIONS
+ ****************************************************************************************
+ */
+
+/* IPC TX descriptor interrupt mask */
+#define IPC_IRQ_A2E_TXDESC          0xFF00
+
+#define IPC_IRQ_A2E_TXDESC_FIRSTBIT (8)
+#define IPC_IRQ_A2E_RXBUF_BACK      CO_BIT(5)
+#define IPC_IRQ_A2E_RXDESC_BACK     CO_BIT(4)
+
+#define IPC_IRQ_A2E_MSG             CO_BIT(1)
+#define IPC_IRQ_A2E_DBG             CO_BIT(0)
+
+#define IPC_IRQ_A2E_ALL             (IPC_IRQ_A2E_TXDESC|IPC_IRQ_A2E_MSG|IPC_IRQ_A2E_DBG)
+
+/* IRQs from emb to app */
+#define IPC_IRQ_E2A_TXCFM_POS   7
+
+#define IPC_IRQ_E2A_TXCFM       ((1 << NX_TXQ_CNT) - 1 ) << IPC_IRQ_E2A_TXCFM_POS
+
+#define IPC_IRQ_E2A_RADAR       CO_BIT(6)
+#define IPC_IRQ_E2A_TBTT_SEC    CO_BIT(5)
+#define IPC_IRQ_E2A_TBTT_PRIM   CO_BIT(4)
+#define IPC_IRQ_E2A_RXDESC      CO_BIT(3)
+#define IPC_IRQ_E2A_MSG_ACK     CO_BIT(2)
+#define IPC_IRQ_E2A_MSG         CO_BIT(1)
+#define IPC_IRQ_E2A_DBG         CO_BIT(0)
+
+#define IPC_IRQ_E2A_ALL         ( IPC_IRQ_E2A_TXCFM         \
+                                | IPC_IRQ_E2A_RXDESC        \
+                                | IPC_IRQ_E2A_MSG_ACK       \
+                                | IPC_IRQ_E2A_MSG           \
+                                | IPC_IRQ_E2A_DBG           \
+                                | IPC_IRQ_E2A_TBTT_PRIM     \
+                                | IPC_IRQ_E2A_TBTT_SEC      \
+                                | IPC_IRQ_E2A_RADAR)
+#endif /* IPC_SHARED_H_ */

--- a/include/bouffalolab/bl60x/wifi/lmac_mac.h
+++ b/include/bouffalolab/bl60x/wifi/lmac_mac.h
@@ -1,0 +1,525 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ ****************************************************************************************
+ *
+ * @file lmac_mac.h
+ * Copyright (C) Bouffalo Lab 2016-2018
+ *
+ ****************************************************************************************
+ */
+
+
+#ifndef LMAC_MAC_H_
+#define LMAC_MAC_H_
+
+/**
+ ****************************************************************************************
+ * @defgroup MAC MAC
+ * @ingroup COMMON
+ * @brief  Common defines,structures
+ *
+ * This module contains defines commonaly used for MAC
+ * @{
+ ****************************************************************************************
+ */
+
+/*
+ * INCLUDE FILES
+ ****************************************************************************************
+ */
+
+
+/*
+ * DEFINES
+ ****************************************************************************************
+ */
+/* duration of a Time Unit in microseconds */
+#define TU_DURATION                     1024
+
+/* max number of channels in the 2.4 GHZ band */
+#define MAC_DOMAINCHANNEL_24G_MAX       14
+
+/* max number of channels in the 5 GHZ band */
+#define MAC_DOMAINCHANNEL_5G_MAX        45
+
+/* Mask to test if it's a basic rate - BIT(7) */
+#define MAC_BASIC_RATE                  0x80
+/* Mask for extracting/checking word alignment */
+#define WORD_ALIGN                      3
+
+#define MAX_AMSDU_LENGTH                7935
+
+/*
+ * MACRO DEFINITIONS
+ ****************************************************************************************
+ */
+
+/**
+ ****************************************************************************************
+ * Compare two MAC addresses.
+ * The MAC addresses MUST be 16 bit aligned.
+ * @param[in] addr1_ptr Pointer to the first MAC address.
+ * @param[in] addr2_ptr Pointer to the second MAC address.
+ * @return True if equal, false if not.
+ ****************************************************************************************
+ */
+#define MAC_ADDR_CMP(addr1_ptr, addr2_ptr)                                              \
+    ((*(((u8*)(addr1_ptr)) + 0) == *(((u8*)(addr2_ptr)) + 0)) &&            \
+     (*(((u8*)(addr1_ptr)) + 1) == *(((u8*)(addr2_ptr)) + 1)) &&            \
+     (*(((u8*)(addr1_ptr)) + 2) == *(((u8*)(addr2_ptr)) + 2)) &&            \
+     (*(((u8*)(addr1_ptr)) + 3) == *(((u8*)(addr2_ptr)) + 3)) &&            \
+     (*(((u8*)(addr1_ptr)) + 4) == *(((u8*)(addr2_ptr)) + 4)) &&            \
+     (*(((u8*)(addr1_ptr)) + 5) == *(((u8*)(addr2_ptr)) + 5)))
+
+/**
+ ****************************************************************************************
+ * Compare two MAC addresses whose alignment is not known.
+ * @param[in] __a1 Pointer to the first MAC address.
+ * @param[in] __a2 Pointer to the second MAC address.
+ * @return True if equal, false if not.
+ ****************************************************************************************
+ */
+#define MAC_ADDR_CMP_PACKED(__a1, __a2)                                                 \
+    (memcmp(__a1, __a2, MAC_ADDR_LEN) == 0)
+
+/**
+ ****************************************************************************************
+ * Copy a MAC address.
+ * The MAC addresses MUST be 16 bit aligned.
+ * @param[in] addr1_ptr Pointer to the destination MAC address.
+ * @param[in] addr2_ptr Pointer to the source MAC address.
+ ****************************************************************************************
+ */
+#define MAC_ADDR_CPY(addr1_ptr, addr2_ptr)                                              \
+    *(((u16*)(addr1_ptr)) + 0) = *(((u16*)(addr2_ptr)) + 0);                  \
+    *(((u16*)(addr1_ptr)) + 1) = *(((u16*)(addr2_ptr)) + 1);                  \
+    *(((u16*)(addr1_ptr)) + 2) = *(((u16*)(addr2_ptr)) + 2)
+
+/**
+ ****************************************************************************************
+ * Compare two SSID.
+ * @param ssid1_ptr Pointer to the first SSID structure.
+ * @param ssid2_ptr Pointer to the second SSID structure.
+ * @return True if equal, false if not.
+ ****************************************************************************************
+ */
+#define MAC_SSID_CMP(ssid1_ptr,ssid2_ptr)                                               \
+    (((ssid1_ptr)->length == (ssid2_ptr)->length) &&                                    \
+     (memcmp((&(ssid1_ptr)->array[0]), (&(ssid2_ptr)->array[0]), (ssid1_ptr)->length) == 0))
+
+/* Check if MAC address is a group address: test the multicast bit. */
+#define MAC_ADDR_GROUP(mac_addr_ptr) ((*(mac_addr_ptr)) & 1)
+
+/* MAC address length in bytes. */
+#define MAC_ADDR_LEN 6
+
+/* MAC address structure. */
+struct mac_addr
+{
+    /* Array of bytes that make up the MAC address. */
+    u8_l array[MAC_ADDR_LEN];
+};
+
+/* SSID maximum length. */
+#define MAC_SSID_LEN 32
+
+/* SSID. */
+struct mac_ssid
+{
+    /* Actual length of the SSID. */
+    u8_l length;
+    /* Array containing the SSID name. */
+    u8_l array[MAC_SSID_LEN];
+    u8_l array_tail[1]; /* for MAX SSID ISSUE */
+};
+
+/* MAC RATE-SET */
+#define MAC_RATESET_LEN             12
+#define MAC_OFDM_PHY_RATESET_LEN    8
+#define MAC_EXT_RATES_OFF      8
+struct mac_rateset
+{
+    u8_l     length;
+    u8_l     array[MAC_RATESET_LEN];
+};
+
+/* MAC RATES */
+#define MAC_MCS_WORD_CNT            3
+struct mac_rates
+{
+    /* MCS 0 to 76 */
+    u32 mcs[MAC_MCS_WORD_CNT];
+    /* Legacy rates (1Mbps to 54Mbps) */
+    u16 legacy;
+};
+
+/* IV/EIV data */
+#define MAC_IV_LEN  4
+#define MAC_EIV_LEN 4
+struct rx_seciv
+{
+    u8 iv[MAC_IV_LEN];
+    u8 ext_iv[MAC_EIV_LEN];
+};
+
+/* MAC MCS SET */
+#define MAX_MCS_LEN 16 /* 16 * 8 = 128 */
+struct mac_mcsset
+{
+    u8 length;
+    u8 array[MAX_MCS_LEN];
+};
+
+/* MAC Secret Key */
+#define MAC_WEP_KEY_CNT          4 /* Number of WEP keys per virtual device */
+#define MAC_WEP_KEY_LEN         13 /* Max size of a WEP key (104/8 = 13) */
+struct mac_wep_key
+{
+    u8 array[MAC_WEP_KEY_LEN]; /* Key material */
+};
+
+
+/* MAC Secret Key */
+#define MAC_SEC_KEY_LEN         32 /* TKIP keys 256 bits (max length) with MIC keys */
+struct mac_sec_key
+{
+    u8_l length; /* Key material length */
+    u32_l array[MAC_SEC_KEY_LEN/4]; /* Key material */
+};
+
+/* MAC channel list */
+/* @todo: fix that number */
+#define MAC_MAX_CH 40
+struct mac_ch_list
+{
+    /* Number of channels in channel list. */
+    u16 nbr;
+    /* List of the channels. */
+    u8 list[MAC_MAX_CH];
+};
+
+
+struct mac_country_subband
+{
+    /* First channel number of the triplet. */
+    u8 first_chn;
+    /* Max number of channel number for the triplet. */
+    u8 nbr_of_chn;
+    /* Maximum allowed transmit power. */
+    u8 max_tx_power;
+};
+
+#define MAX_COUNTRY_LEN         3
+#define MAX_COUNTRY_SUBBAND     5
+struct mac_country
+{
+    /* Length of the country string */
+    u8 length;
+    /* Country  string 2 char. */
+    u8 string[MAX_COUNTRY_LEN];
+    /* channel info triplet */
+    struct mac_country_subband subband[MAX_COUNTRY_SUBBAND];
+};
+
+/* MAC HT CAPABILITY */
+struct mac_htcapability
+{
+    u16_l       ht_capa_info;
+    u8_l        a_mpdu_param;
+    u8_l        mcs_rate[MAX_MCS_LEN];
+    u16_l       ht_extended_capa;
+    u32_l       tx_beamforming_capa;
+    u8_l        asel_capa;
+};
+
+/* MAC VHT CAPABILITY */
+struct mac_vhtcapability
+{
+    u32_l       vht_capa_info;
+    u16_l       rx_mcs_map;
+    u16_l       rx_highest;
+    u16_l       tx_mcs_map;
+    u16_l       tx_highest;
+};
+
+
+/* MAC HT CAPABILITY */
+struct mac_htoprnelmt
+{
+    u8     prim_channel;
+    u8     ht_oper_1;
+    u16    ht_oper_2;
+    u16    ht_oper_3;
+    u8     mcs_rate[MAX_MCS_LEN];
+
+};
+
+/* MAC QOS CAPABILITY */
+struct mac_qoscapability
+{
+    u8  qos_info;
+};
+
+/* RSN information element */
+#define MAC_RAW_RSN_IE_LEN 34
+struct mac_raw_rsn_ie
+{
+    u8 data[2 + MAC_RAW_RSN_IE_LEN];
+};
+
+#define MAC_RAW_ENC_LEN 0x1A
+struct mac_wpa_frame
+{
+    u8 array[MAC_RAW_ENC_LEN];
+};
+
+#define MAC_WME_PARAM_LEN          16
+struct mac_wmm_frame
+{
+    u8 array [MAC_WME_PARAM_LEN];
+};
+
+/* BSS load element */
+struct mac_bss_load
+{
+    u16 sta_cnt;
+    u8  ch_utilization;
+    u16 avail_adm_capacity;
+};
+
+/* EDCA Parameter Set Element */
+struct  mac_edca_param_set
+{
+    u8         qos_info;
+    u32        ac_be_param_record;
+    u32        ac_bk_param_record;
+    u32        ac_vi_param_record;
+    u32        ac_vo_param_record;
+};
+
+
+/* MAC Twenty Forty BSS */
+
+struct mac_twenty_fourty_bss
+{
+    u8 bss_coexistence;
+};
+
+/* MAC BA PARAMETERS */
+struct mac_ba_param
+{
+    struct mac_addr   peer_sta_address; /* Peer STA MAC Address to which BA is Setup */
+    u16          buffer_size; /* Number of buffers available for this BA */
+    u16          start_sequence_number; /* Start Sequence Number of BA */
+    u16          ba_timeout; /* BA Setup timeout value */
+    u8           dev_type; /* BA Device Type Originator/Responder */
+    u8           block_ack_policy; /* BLOCK-ACK Policy Setup Immedaite/Delayed */
+    u8           buffer_cnt; /* Number of buffers required for BA Setup */
+};
+
+/* MAC TS INFO field */
+struct mac_ts_info
+{
+    u8   traffic_type;
+    u8   ack_policy;
+    u8   access_policy;
+    u8   dir;
+    u8   tsid;
+    u8   user_priority;
+    bool      aggregation;
+    bool      apsd;
+    bool      schedule;
+};
+
+/* MAC TSPEC PARAMETERS */
+struct mac_tspec_param
+{
+    struct mac_ts_info ts_info;
+    u16  nominal_msdu_size;
+    u16  max_msdu_size;
+    u32  min_service_interval;
+    u32  max_service_interval;
+    u32  inactivity_interval;
+    u32  short_inactivity_interval;
+    u32  service_start_time;
+    u32  max_burst_size;
+    u32  min_data_rate;
+    u32  mean_data_rate;
+    u32  min_phy_rate;
+    u32  peak_data_rate;
+    u32  delay_bound;
+    u16  medium_time;
+    u8   surplusbwallowance;
+};
+
+/* Scan result element, parsed from beacon or probe response frames. */
+struct mac_scan_result
+{
+    /* Network BSSID. */
+    struct mac_addr bssid;
+    /* Network type (IBSS or ESS). */
+    u16 bsstype;
+    /* Network channel number. */
+    u16 ch_nbr;
+    /* Network beacon period. */
+    u16 beacon_period;
+    u32 timestamp_high;
+    u32 timestamp_low;
+    u16 dtim_period;
+    u16 ibss_parameter;
+    u16 cap_info;
+    struct mac_rateset rate_set;
+    struct mac_bss_load bss_load;
+    u8 country_element[3];
+    struct mac_edca_param_set edca_param;
+    struct mac_raw_rsn_ie rsn_ie;
+    struct mac_qoscapability qos_cap;
+    struct mac_htcapability ht_cap;
+    u8 sec_ch_oft;
+    struct mac_twenty_fourty_bss twenty_fourty_bss;
+    bool valid_flag;
+    u8 rssi;
+};
+
+/* Structure containing the information required to perform a measurement request */
+struct mac_request_set
+{
+
+    u8             mode; /* As specified by standard */
+    u8             type; /* 0: Basic request, 1: CCA request, 2: RPI histogram request */
+    u16            duration; /* In TU */
+    uint64_t            start_time; /* TSF time */
+    u8             ch_number; /* channel to be measured */
+};
+
+/* Structure containing the information returned from a measurement process */
+struct mac_report_set
+{
+    u8             mode; /* As specified by standard */
+    u8             type; /* 0: Basic request, 1: CCA request, 2: RPI histogram request */
+    u16            duration; /* In TU */
+    uint64_t            start_time; /* TSF time */
+    u8             ch_number; /* channel to be measured */
+    u8             map; /* As specified by standard */
+    u8             cca_busy_fraction; /* As specified by standard */
+    u8             rpi_histogram[8]; /* As specified by standard */
+};
+
+/* Structure containing the MAC SW and MAC HW version information */
+struct mac_version
+{
+    char mac_sw_version[16];
+    char mac_sw_version_date[48];
+    char mac_sw_build_date[48];
+    u32 mac_hw_version1;
+    u32 mac_hw_version2;
+};
+
+/* Structure containing some of the properties of a BSS. @todo Add required fields during */
+/* AP/IBSS mode implementation */
+struct mac_bss_conf
+{
+    /* Flags (ERP, QoS, etc.). */
+    u32 flags;
+    /* Beacon period */
+    u16 beacon_period;
+};
+
+/* Traffic ID enumeration */
+enum
+{
+    TID_0,
+    TID_1,
+    TID_2,
+    TID_3,
+    TID_4,
+    TID_5,
+    TID_6,
+    TID_7,
+    TID_MGT,
+    TID_MAX
+};
+
+/* Access Category enumeration */
+enum
+{
+    AC_BK = 0,
+    AC_BE,
+    AC_VI,
+    AC_VO,
+    AC_MAX
+};
+
+/* SCAN type */
+enum
+{
+    SCAN_PASSIVE,
+    SCAN_ACTIVE
+};
+
+/* rates */
+enum
+{
+    MAC_RATE_1MBPS   =   2,
+    MAC_RATE_2MBPS   =   4,
+    MAC_RATE_5_5MBPS =  11,
+    MAC_RATE_6MBPS   =  12,
+    MAC_RATE_9MBPS   =  18,
+    MAC_RATE_11MBPS  =  22,
+    MAC_RATE_12MBPS  =  24,
+    MAC_RATE_18MBPS  =  36,
+    MAC_RATE_24MBPS  =  48,
+    MAC_RATE_36MBPS  =  72,
+    MAC_RATE_48MBPS  =  96,
+    MAC_RATE_54MBPS  = 108
+};
+
+/* Station flags */
+enum
+{
+    /* Bit indicating that a STA has QoS (WMM) capability */
+    STA_QOS_CAPA = 1 << 0,
+    /* Bit indicating that a STA has HT capability */
+    STA_HT_CAPA = 1 << 1,
+    /* Bit indicating that a STA has VHT capability */
+    STA_VHT_CAPA = 1 << 2,
+    /* Bit indicating that a STA has MFP capability */
+    STA_MFP_CAPA = 1 << 3,
+    /* Bit indicating that the STA included the Operation Notification IE */
+    STA_OPMOD_NOTIF = 1 << 4,
+};
+
+/* Connection flags */
+enum
+{
+    /* Flag indicating whether the control port is controlled by host or not */
+    CONTROL_PORT_HOST = 1 << 0,
+    /* Flag indicating whether the control port frame shall be sent unencrypted */
+    CONTROL_PORT_NO_ENC = 1 << 1,
+    /* Flag indicating whether HT shall be disabled or not */
+    DISABLE_HT = 1 << 2,
+    /* Flag indicating whether WPA or WPA2 authentication is in use */
+    WPA_WPA2_IN_USE = 1 << 3,
+    /* Flag indicating whether MFP is in use */
+    MFP_IN_USE = 1 << 4,
+};
+
+/*
+* GLOBAL VARIABLES
+****************************************************************************************
+*/
+extern const u8 mac_tid2ac[];
+
+extern const u8 mac_id2rate[];
+
+extern const u16 mac_mcs_params_20[];
+
+extern const u16 mac_mcs_params_40[];
+
+/* @} */
+
+#endif /* LMAC_MAC_H_ */

--- a/include/bouffalolab/bl60x/wifi/lmac_msg.h
+++ b/include/bouffalolab/bl60x/wifi/lmac_msg.h
@@ -1,0 +1,1368 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ ****************************************************************************************
+ *
+ * @file lmac_msg.h
+ * Copyright (C) Bouffalo Lab 2016-2018
+ *
+ ****************************************************************************************
+ */
+
+
+#ifndef LMAC_MSG_H_
+#define LMAC_MSG_H_
+
+/*
+ * INCLUDE FILES
+ ****************************************************************************************
+ */
+/* for MAC related elements (mac_addr, mac_ssid...) */
+#define MAX_PSK_PASS_PHRASE_LEN 64
+
+/*
+ ****************************************************************************************
+ */
+
+/* Power Save mode setting */
+enum mm_ps_mode_state
+{
+    MM_PS_MODE_OFF,
+    MM_PS_MODE_ON,
+    MM_PS_MODE_ON_DYN,
+};
+
+/* Status/error codes used in the MAC software. */
+enum
+{
+    CO_OK,
+    CO_FAIL,
+    CO_EMPTY,
+    CO_FULL,
+    CO_BAD_PARAM,
+    CO_NOT_FOUND,
+    CO_NO_MORE_ELT_AVAILABLE,
+    CO_NO_ELT_IN_USE,
+    CO_BUSY,
+    CO_OP_IN_PROGRESS,
+};
+
+/* WiFi Mode */
+typedef enum {
+    /* 802.ll b */
+    WIFI_MODE_802_11B       = 0x01,
+    /* 802.11 a */
+    WIFI_MODE_802_11A       = 0x02,
+    /* 802.11 g */
+    WIFI_MODE_802_11G       = 0x04,
+    /* 802.11n at 2.4GHz */
+    WIFI_MODE_802_11N_2_4   = 0x08,
+    /* 802.11n at 5GHz */
+    WIFI_MODE_802_11N_5     = 0x10,
+    /* 802.11ac at 5GHz */
+    WIFI_MODE_802_11AC_5    = 0x20,
+    /* Reserved for future use */
+    WIFI_MODE_RESERVED      = 0x40,
+} WiFi_Mode_t;
+
+/* Remain on channel operation codes */
+enum mm_remain_on_channel_op
+{
+    MM_ROC_OP_START = 0,
+    MM_ROC_OP_CANCEL,
+};
+
+#define DRV_TASK_ID 100
+
+#define MSG_T(msg) (((msg) >> 10))
+#define MSG_I(msg) ((msg) & ((1<<10)-1))
+
+/* The two following definitions are needed for message structure consistency */
+/* Structure of a list element header */
+/* Message structure. */
+/* Use explicit sizes so layout matches the blob (built with -fshort-enums) */
+/* regardless of host compile flags. */
+struct lmac_msg
+{
+    uint16_t   id; /* Message id (was ke_msg_id_t). */
+    uint8_t    dest_id; /* Destination task (was ke_task_id_t). */
+    uint8_t    src_id; /* Source task (was ke_task_id_t). */
+    u32        param_len; /* Parameter embedded struct length. */
+    u32        param[]; /* Parameter embedded struct. Must be word-aligned. */
+};
+
+/* Interface types */
+enum
+{
+    /* ESS STA interface */
+    MM_STA,
+    /* IBSS STA interface */
+    MM_IBSS,
+    /* AP interface */
+    MM_AP,
+    /* Mesh Point interface */
+    MM_MESH_POINT,
+};
+
+/* Maximum number of words in the configuration buffer */
+#define PHY_CFG_BUF_SIZE     16
+
+/* Structure containing the parameters of the PHY configuration */
+struct phy_cfg_tag
+{
+    /* Buffer containing the parameters specific for the PHY used */
+    u32_l parameters[PHY_CFG_BUF_SIZE];
+};
+
+/* Structure containing the parameters of the @ref MM_MONITOR_CFM message. */
+struct mm_monitor_cfm
+{
+    uint32_t status;
+    uint32_t enable;
+    uint32_t data[8];
+};
+
+/* Structure containing the parameters of the Trident PHY configuration */
+struct phy_trd_cfg_tag
+{
+    /* MDM type(nxm)(upper nibble) and MDM2RF path mapping(lower nibble) */
+    u8_l path_mapping;
+    /* TX DC offset compensation */
+    u32_l tx_dc_off_comp;
+};
+
+/* Structure containing the parameters of the Karst PHY configuration */
+struct phy_karst_cfg_tag
+{
+    /* TX IQ mismatch compensation in 2.4GHz */
+    u32_l tx_iq_comp_2_4G[2];
+    /* RX IQ mismatch compensation in 2.4GHz */
+    u32_l rx_iq_comp_2_4G[2];
+    /* TX IQ mismatch compensation in 5GHz */
+    u32_l tx_iq_comp_5G[2];
+    /* RX IQ mismatch compensation in 5GHz */
+    u32_l rx_iq_comp_5G[2];
+    /* RF path used by default (0 or 1) */
+    u8_l path_used;
+};
+
+/* Structure containing the parameters of the @ref MM_START_REQ message */
+struct mm_start_req
+{
+    /* PHY configuration */
+    struct phy_cfg_tag phy_cfg;
+    /* UAPSD timeout */
+    u32_l uapsd_timeout;
+    /* Local LP clock accuracy (in ppm) */
+    u16_l lp_clk_accuracy;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_CHANNEL_REQ message */
+struct mm_set_channel_req
+{
+    /* Band (2.4GHz or 5GHz) */
+    u8_l band;
+    /* Channel type: 20,40,80,160 or 80+80 MHz */
+    u8_l type;
+    /* Frequency for Primary 20MHz channel (in MHz) */
+    u16_l prim20_freq;
+    /* Frequency for Center of the contiguous channel or center of Primary 80+80 */
+    u16_l center1_freq;
+    /* Frequency for Center of the non-contiguous secondary 80+80 */
+    u16_l center2_freq;
+    /* Index of the RF for which the channel has to be set (0: operating (primary), 1: secondary */
+    /* RF (used for additional radar detection). This parameter is reserved if no secondary RF */
+    /* is available in the system */
+    u8_l index;
+    /* Max tx power for this channel */
+    s8_l tx_power;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_CHANNEL_CFM message */
+struct mm_set_channel_cfm
+{
+    /* Radio index to be used in policy table */
+    u8_l radio_idx;
+    /* TX power configured (in dBm) */
+    s8_l power;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_DTIM_REQ message */
+struct mm_set_dtim_req
+{
+    /* DTIM period */
+    u8_l dtim_period;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_POWER_REQ message */
+struct mm_set_power_req
+{
+    /* Index of the interface for which the parameter is configured */
+    u8_l inst_nbr;
+    /* TX power (in dBm) */
+    s8_l power;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_POWER_CFM message */
+struct mm_set_power_cfm
+{
+    /* Radio index to be used in policy table */
+    u8_l radio_idx;
+    /* TX power configured (in dBm) */
+    s8_l power;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_BEACON_INT_REQ message */
+struct mm_set_beacon_int_req
+{
+    /* Beacon interval */
+    u16_l beacon_int;
+    /* Index of the interface for which the parameter is configured */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_BEACON_INT_CFM message */
+struct mm_set_beacon_int_cfm
+{
+    u8_l status;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_BASIC_RATES_REQ message */
+struct mm_set_basic_rates_req
+{
+    /* Basic rate set (as expected by bssBasicRateSet field of Rates MAC HW register) */
+    u32_l rates;
+    /* Index of the interface for which the parameter is configured */
+    u8_l inst_nbr;
+    /* Band on which the interface will operate */
+    u8_l band;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_BSSID_REQ message */
+struct mm_set_bssid_req
+{
+    /* BSSID to be configured in HW */
+    struct mac_addr bssid;
+    /* Index of the interface for which the parameter is configured */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_ADD_IF_REQ message. */
+struct mm_add_if_req
+{
+    /* Type of the interface (AP, STA, ADHOC, ...) */
+    u8_l type;
+    /* MAC ADDR of the interface to start */
+    struct mac_addr addr;
+    /* P2P Interface */
+    bool_l p2p;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_EDCA_REQ message */
+struct mm_set_edca_req
+{
+    /* EDCA parameters of the queue (as expected by edcaACxReg HW register) */
+    u32_l ac_param;
+    /* Flag indicating if UAPSD can be used on this queue */
+    bool_l uapsd;
+    /* HW queue for which the parameters are configured */
+    u8_l hw_queue;
+    /* Index of the interface for which the parameters are configured */
+    u8_l inst_nbr;
+};
+
+struct mm_set_idle_req
+{
+    u8_l hw_idle;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_MODE_REQ message */
+struct mm_set_mode_req
+{
+    /* abgnMode field of macCntrl1Reg register */
+    u8_l abgnmode;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_VIF_STATE_REQ message */
+struct mm_set_vif_state_req
+{
+    /* Association Id received from the AP (valid only if the VIF is of STA type) */
+    u16_l aid;
+    /* Flag indicating if the VIF is active or not */
+    bool_l active;
+    /* Interface index */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_ADD_IF_CFM message. */
+struct mm_add_if_cfm
+{
+    /* Status of operation (different from 0 if unsuccessful) */
+    u8_l status;
+    /* Interface index assigned by the LMAC */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_REMOVE_IF_REQ message. */
+struct mm_remove_if_req
+{
+    /* Interface index assigned by the LMAC */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_VERSION_CFM message. */
+struct mm_version_cfm
+{
+    /* Version of the LMAC FW */
+    u32_l version_lmac;
+    /* Version1 of the MAC HW (as encoded in version1Reg MAC HW register) */
+    u32_l version_machw_1;
+    /* Version2 of the MAC HW (as encoded in version2Reg MAC HW register) */
+    u32_l version_machw_2;
+    /* Version1 of the PHY (depends on actual PHY) */
+    u32_l version_phy_1;
+    /* Version2 of the PHY (depends on actual PHY) */
+    u32_l version_phy_2;
+    /* Supported Features */
+    u32_l features;
+};
+
+/* Structure containing the parameters of the @ref MM_STA_ADD_REQ message. */
+struct mm_sta_add_req
+{
+    /* PAID/GID */
+    u32_l paid_gid;
+    /* Maximum A-MPDU size, in bytes, for HT frames */
+    u16_l ampdu_size_max_ht;
+    /* MAC address of the station to be added */
+    struct mac_addr mac_addr;
+    /* A-MPDU spacing, in us */
+    u8_l ampdu_spacing_min;
+    /* Interface index */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_STA_ADD_CFM message. */
+struct mm_sta_add_cfm
+{
+    /* Status of the operation (different from 0 if unsuccessful) */
+    u8_l status;
+    /* Index assigned by the LMAC to the newly added station */
+    u8_l sta_idx;
+    /* MAC HW index of the newly added station */
+    u8_l hw_sta_idx;
+};
+
+/* Structure containing the parameters of the @ref MM_STA_DEL_REQ message. */
+struct mm_sta_del_req
+{
+    /* Index of the station to be deleted */
+    u8_l sta_idx;
+    /* VIF on which remain on channel operation has been started (if roc == 1) */
+    u8_l vif_index;
+};
+
+/* Structure containing the parameters of the @ref MM_STA_DEL_CFM message. */
+struct mm_sta_del_cfm
+{
+    /* Status of the operation (different from 0 if unsuccessful) */
+    u8_l     status;
+    /* VIF on which remain on channel operation has been started (if roc == 1) */
+    u8_l vif_index;
+};
+
+/* Structure containing the parameters of the SET_POWER_MODE REQ message. */
+struct mm_setpowermode_req
+{
+    u8_l mode;
+    u8_l sta_idx;
+};
+
+/* Structure containing the parameters of the SET_POWER_MODE CFM message. */
+struct mm_setpowermode_cfm
+{
+    u8_l     status;
+};
+
+/* Structure containing the parameters of the @ref MM_MONITOR_REQ message. */
+struct mm_monitor_req
+{
+    uint32_t enable;
+};
+
+/* Structure containing the parameters of the @ref MM_MONITOR_CHANNEL_REQ message. */
+struct mm_monitor_channel_req
+{
+    uint32_t freq;
+};
+
+/* Structure containing the parameters of the @ref MM_MONITOR_CHANNEL_CFM message. */
+struct mm_monitor_channel_cfm
+{
+    uint32_t status;
+    uint32_t freq;
+    uint32_t data[8];
+};
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_ADD_REQ message */
+struct mm_chan_ctxt_add_req
+{
+    /* Band (2.4GHz or 5GHz) */
+    u8_l band;
+    /* Channel type: 20,40,80,160 or 80+80 MHz */
+    u8_l type;
+    /* Frequency for Primary 20MHz channel (in MHz) */
+    u16_l prim20_freq;
+    /* Frequency for Center of the contiguous channel or center of Primary 80+80 */
+    u16_l center1_freq;
+    /* Frequency for Center of the non-contiguous secondary 80+80 */
+    u16_l center2_freq;
+    /* Max tx power for this channel */
+    s8_l tx_power;
+};
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_ADD_REQ message */
+struct mm_chan_ctxt_add_cfm
+{
+    /* Status of the addition */
+    u8_l status;
+    /* Index of the new channel context */
+    u8_l index;
+};
+
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_DEL_REQ message */
+struct mm_chan_ctxt_del_req
+{
+    /* Index of the new channel context to be deleted */
+    u8_l index;
+};
+
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_LINK_REQ message */
+struct mm_chan_ctxt_link_req
+{
+    /* VIF index */
+    u8_l vif_index;
+    /* Channel context index */
+    u8_l chan_index;
+    /* Indicate if this is a channel switch (unlink current ctx first if true) */
+    u8_l chan_switch;
+};
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_UNLINK_REQ message */
+struct mm_chan_ctxt_unlink_req
+{
+    /* VIF index */
+    u8_l vif_index;
+};
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_UPDATE_REQ message */
+struct mm_chan_ctxt_update_req
+{
+    /* Channel context index */
+    u8_l chan_index;
+    /* Band (2.4GHz or 5GHz) */
+    u8_l band;
+    /* Channel type: 20,40,80,160 or 80+80 MHz */
+    u8_l type;
+    /* Frequency for Primary 20MHz channel (in MHz) */
+    u16_l prim20_freq;
+    /* Frequency for Center of the contiguous channel or center of Primary 80+80 */
+    u16_l center1_freq;
+    /* Frequency for Center of the non-contiguous secondary 80+80 */
+    u16_l center2_freq;
+};
+
+/* Structure containing the parameters of the @ref MM_CHAN_CTXT_SCHED_REQ message */
+struct mm_chan_ctxt_sched_req
+{
+    /* VIF index */
+    u8_l vif_index;
+    /* Channel context index */
+    u8_l chan_index;
+    /* Type of the scheduling request (0: normal scheduling, 1: derogatory */
+    /* scheduling) */
+    u8_l type;
+};
+
+/* Structure containing the parameters of the @ref MM_CHANNEL_SWITCH_IND message */
+struct mm_channel_switch_ind
+{
+    /* Index of the channel context we will switch to */
+    u8_l chan_index;
+    /* Indicate if the switch has been triggered by a Remain on channel request */
+    bool_l roc;
+    /* VIF on which remain on channel operation has been started (if roc == 1) */
+    u8_l vif_index;
+    /* Indicate if the switch has been triggered by a TDLS Remain on channel request */
+    bool_l roc_tdls;
+};
+
+/* Structure containing the parameters of the @ref MM_CHANNEL_PRE_SWITCH_IND message */
+struct mm_channel_pre_switch_ind
+{
+    /* Index of the channel context we will switch to */
+    u8_l chan_index;
+};
+
+/* Structure containing the parameters of the @ref MM_CONNECTION_LOSS_IND message. */
+struct mm_connection_loss_ind
+{
+    /* VIF instance number */
+    u8_l inst_nbr;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_PS_MODE_REQ message. */
+struct mm_set_ps_mode_req
+{
+    /* Power Save is activated or deactivated */
+    u8_l  new_state;
+};
+
+struct mm_set_denoise_req
+{
+    u8_l  denoise_mode;
+};
+
+/* Structure containing the parameters of the @ref MM_BCN_CHANGE_REQ message. */
+#define BCN_MAX_CSA_CPT 2
+struct mm_bcn_change_req
+{
+    /* Pointer, in host memory, to the new beacon template */
+    u32_l bcn_ptr;
+    /* Length of the beacon template */
+    u16_l bcn_len;
+    /* Offset of the TIM IE in the beacon */
+    u16_l tim_oft;
+    /* Length of the TIM IE */
+    u8_l tim_len;
+    /* Index of the VIF for which the beacon is updated */
+    u8_l inst_nbr;
+    /* Offset of CSA (channel switch announcement) counters (0 means no counter) */
+    u8_l csa_oft[BCN_MAX_CSA_CPT];
+};
+
+
+/* Structure containing the parameters of the @ref MM_TIM_UPDATE_REQ message. */
+struct mm_tim_update_req
+{
+    /* Association ID of the STA the bit of which has to be updated (0 for BC/MC traffic) */
+    u16_l aid;
+    /* Flag indicating the availability of data packets for the given STA */
+    u8_l tx_avail;
+    /* Index of the VIF for which the TIM is updated */
+    u8_l inst_nbr;
+};
+
+
+/* Structure containing the parameters of the @ref MM_REMAIN_ON_CHANNEL_REQ message. */
+struct mm_remain_on_channel_req
+{
+    /* Operation Code */
+    u8_l op_code;
+    /* VIF Index */
+    u8_l vif_index;
+    /* Duration */
+    u32_l duration_ms;
+    /* Parameters of the channel */
+    struct mm_chan_ctxt_add_req channel;
+};
+
+/* Structure containing the parameters of the @ref MM_REMAIN_ON_CHANNEL_CFM message */
+struct mm_remain_on_channel_cfm
+{
+    /* Operation Code */
+    u8_l op_code;
+    /* Status of the operation */
+    u8_l status;
+    /* Channel Context index */
+    u8_l chan_ctxt_index;
+};
+
+/* Structure containing the parameters of the @ref MM_REMAIN_ON_CHANNEL_EXP_IND message */
+struct mm_remain_on_channel_exp_ind
+{
+    /* VIF Index */
+    u8_l vif_index;
+    /* Channel Context index */
+    u8_l chan_ctxt_index;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_UAPSD_TMR_REQ message. */
+struct mm_set_uapsd_tmr_req
+{
+    /* action: Start or Stop the timer */
+    u8_l  action;
+    /* timeout value, in milliseconds */
+    u32_l  timeout;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_UAPSD_TMR_CFM message. */
+struct mm_set_uapsd_tmr_cfm
+{
+    /* Status of the operation (different from 0 if unsuccessful) */
+    u8_l     status;
+};
+
+
+/* Structure containing the parameters of the @ref MM_PS_CHANGE_IND message */
+struct mm_ps_change_ind
+{
+    /* Index of the peer device that is switching its PS state */
+    u8_l sta_idx;
+    /* New PS state of the peer device (0: active, 1: sleeping) */
+    u8_l ps_state;
+};
+
+/* Structure containing the parameters of the @ref MM_TRAFFIC_REQ_IND message */
+struct mm_traffic_req_ind
+{
+    /* Index of the peer device that needs traffic */
+    u8_l sta_idx;
+    /* Number of packets that need to be sent (if 0, all buffered traffic shall be sent) */
+    u8_l pkt_cnt;
+    /* Flag indicating if the traffic request concerns U-APSD queues or not */
+    bool_l uapsd;
+};
+
+/* Structure containing the parameters of the @ref MM_SET_PS_OPTIONS_REQ message. */
+struct mm_set_ps_options_req
+{
+    /* VIF Index */
+    u8_l vif_index;
+    /* Listen interval (0 if wake up shall be based on DTIM period) */
+    u16_l listen_interval;
+    /* Flag indicating if we shall listen the BC/MC traffic or not */
+    bool_l dont_listen_bc_mc;
+};
+
+/* Structure containing the parameters of the @ref MM_CSA_COUNTER_IND message */
+struct mm_csa_counter_ind
+{
+    /* Index of the VIF */
+    u8_l vif_index;
+    /* Updated CSA counter value */
+    u8_l csa_count;
+};
+
+/* Structure containing the parameters of the @ref MM_CHANNEL_SURVEY_IND message */
+struct mm_channel_survey_ind
+{
+    /* Frequency of the channel */
+    u16_l freq;
+    /* Noise in dbm */
+    s8_l noise_dbm;
+    /* Amount of time spent of the channel (in ms) */
+    u32_l chan_time_ms;
+    /* Amount of time the primary channel was sensed busy */
+    u32_l chan_time_busy_ms;
+};
+
+/* Structure containing the parameters of the @ref MM_CFG_RSSI_REQ message */
+struct mm_cfg_rssi_req
+{
+    /* Index of the VIF */
+    u8_l vif_index;
+    /* RSSI threshold */
+    s8_l rssi_thold;
+    /* RSSI hysteresis */
+    u8_l rssi_hyst;
+};
+
+/* Structure containing the parameters of the @ref MM_RSSI_STATUS_IND message */
+struct mm_rssi_status_ind
+{
+    /* Index of the VIF */
+    u8_l vif_index;
+    /* Status of the RSSI */
+    bool_l rssi_status;
+    /* RSSI of current ind */
+    s8_l rssi;
+};
+
+/* Maximum number of SSIDs in a scan request */
+#define SCAN_SSID_MAX  1
+
+/* Maximum number of 2.4GHz channels */
+#define SCAN_CHANNEL_2G4 14
+
+/* Maximum number of 5GHz channels */
+#define SCAN_CHANNEL_5G  28
+
+/* Maximum number of channels in a scan request */
+#define SCAN_CHANNEL_MAX (SCAN_CHANNEL_2G4 + SCAN_CHANNEL_5G)
+
+/* Flag bits */
+#define SCAN_PASSIVE_BIT BIT(0)
+#define SCAN_DISABLED_BIT BIT(1)
+
+/* Definition of a channel to be scanned */
+struct scan_chan_tag
+{
+    /* Frequency of the channel */
+    u16_l freq;
+    /* RF band (0: 2.4GHz, 1: 5GHz) */
+    u8_l band;
+    /* Bit field containing additional information about the channel */
+    u8_l flags;
+    /* Max tx_power for this channel (dBm) */
+    s8_l tx_power;
+};
+
+/* Structure containing the parameters of the @ref SCAN_START_REQ message */
+struct scan_start_req
+{
+    /* List of channel to be scanned */
+    struct scan_chan_tag chan[SCAN_CHANNEL_MAX];
+    /* List of SSIDs to be scanned */
+    struct mac_ssid ssid[SCAN_SSID_MAX];
+    /* BSSID to be scanned */
+    struct mac_addr bssid;
+    /* MAC address used to send probe request */
+    struct mac_addr mac;
+    /* Pointer (in host memory) to the additional IEs that need to be added to the ProbeReq */
+    /* (following the SSID element) */
+    u32_l add_ies;
+    /* Length of the additional IEs */
+    u16_l add_ie_len;
+    /* Index of the VIF that is scanning */
+    u8_l vif_idx;
+    /* Number of channels to scan */
+    u8_l chan_cnt;
+    /* Number of SSIDs to scan for */
+    u8_l ssid_cnt;
+    /* no CCK - For P2P frames not being sent at CCK rate in 2GHz band. */
+    bool no_cck;
+};
+
+/* Structure containing the parameters of the @ref SCAN_START_CFM message */
+struct scan_start_cfm
+{
+    /* Status of the request */
+    u8_l status;
+};
+
+/* Structure containing the parameters of the @ref SCANU_START_REQ message */
+struct scanu_start_req
+{
+    /* List of channel to be scanned */
+    struct scan_chan_tag chan[SCAN_CHANNEL_MAX];
+    /* List of SSIDs to be scanned */
+    struct mac_ssid ssid[SCAN_SSID_MAX];
+    /* BSSID to be scanned (or WILDCARD BSSID if no BSSID is searched in particular) */
+    struct mac_addr bssid;
+    /* MAC address used to send probe request */
+    struct mac_addr mac;
+    /* Address (in host memory) of the additional IEs that need to be added to the ProbeReq */
+    /* (following the SSID element) */
+    u32_l add_ies;
+    /* Length of the additional IEs */
+    u16_l add_ie_len;
+    /* Index of the VIF that is scanning */
+    u8_l vif_idx;
+    /* Number of channels to scan */
+    u8_l chan_cnt;
+    /* Number of SSIDs to scan for */
+    u8_l ssid_cnt;
+    /* no CCK - For P2P frames not being sent at CCK rate in 2GHz band. */
+    bool no_cck;
+    /* MISC flags */
+    uint32_t flags;
+    /* channel scan time */
+    uint32_t duration_scan;
+};
+
+struct scanu_raw_send_req
+{
+    void *pkt;
+    uint32_t len;
+};
+
+struct scanu_raw_send_cfm
+{
+    uint32_t status;
+};
+
+/* Structure containing the parameters of the @ref SCANU_START_CFM message */
+struct scanu_start_cfm
+{
+    /* Status of the request */
+    u8_l status;
+};
+
+/* Parameters of the @SCANU_RESULT_IND message */
+struct scanu_result_ind
+{
+    /* Length of the frame */
+    uint16_t length;
+    /* Frame control field of the frame. */
+    uint16_t framectrl;
+    /* Center frequency on which we received the packet */
+    uint16_t center_freq;
+    /* PHY band */
+    uint8_t band;
+    /* Index of the station that sent the frame. 0xFF if unknown. */
+    uint8_t sta_idx;
+    /* Index of the VIF that received the frame. 0xFF if unknown. */
+    uint8_t inst_nbr;
+    /* Source mac of the received frame. */
+    uint8_t sa[6];
+    /* timestamp of the received frame. */
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    /* RSSI of the received frame. */
+    int8_t rssi;
+    /* Abs. PPM of the received frame */
+    int8_t ppm_abs;
+    /* Rel. PPM of the received frame */
+    int8_t ppm_rel;
+    /* Flags */
+    uint8_t flags;
+    /* Date rate of the received frame. */
+    uint8_t data_rate;
+    /* Frame payload. */
+    uint32_t payload[];
+};
+
+/* Structure containing the parameters of the message. */
+struct scanu_fast_req
+{
+    /* The SSID to scan in the channel. */
+    struct mac_ssid ssid;
+    /* BSSID. */
+    struct mac_addr bssid;
+    /* Probe delay. */
+    u16_l probe_delay;
+    /* Minimum channel time. */
+    u16_l minch_time;
+    /* Maximum channel time. */
+    u16_l maxch_time;
+    /* The channel number to scan. */
+    u16_l ch_nbr;
+};
+
+
+/* Structure containing the parameters of the @ref ME_START_REQ message */
+struct me_config_req
+{
+    /* HT Capabilities */
+    struct mac_htcapability ht_cap;
+    /* VHT Capabilities */
+    struct mac_vhtcapability vht_cap;
+    /* Lifetime of packets sent under a BlockAck agreement (expressed in TUs) */
+    u16_l tx_lft;
+    /* Boolean indicating if HT is supported or not */
+    bool_l ht_supp;
+    /* Boolean indicating if VHT is supported or not */
+    bool_l vht_supp;
+    /* Boolean indicating if PS mode shall be enabled or not */
+    bool_l ps_on;
+};
+
+/* Structure containing the parameters of the @ref ME_CHAN_CONFIG_REQ message */
+struct me_chan_config_req
+{
+    /* List of 2.4GHz supported channels */
+    struct scan_chan_tag chan2G4[SCAN_CHANNEL_2G4];
+    /* Number of 2.4GHz channels in the list */
+    u8_l chan2G4_cnt;
+};
+
+/* Structure containing the parameters of the @ref ME_SET_CONTROL_PORT_REQ message */
+struct me_set_control_port_req
+{
+    /* Index of the station for which the control port is opened */
+    u8_l sta_idx;
+    /* Control port state */
+    bool_l control_port_open;
+};
+
+/* Structure containing the parameters of the @ref ME_TKIP_MIC_FAILURE_IND message */
+struct me_tkip_mic_failure_ind
+{
+    /* Address of the sending STA */
+    struct mac_addr addr;
+    /* TSC value */
+    u64_l tsc;
+    /* Boolean indicating if the packet was a group or unicast one (true if group) */
+    bool_l ga;
+    /* Key Id */
+    u8_l keyid;
+    /* VIF index */
+    u8_l vif_idx;
+};
+
+/* Structure containing the parameters of the @ref ME_STA_ADD_REQ message */
+struct me_sta_add_req
+{
+    /* MAC address of the station to be added */
+    struct mac_addr mac_addr;
+    /* Supported legacy rates */
+    struct mac_rateset rate_set;
+    /* HT Capabilities */
+    struct mac_htcapability ht_cap;
+    /* VHT Capabilities */
+    struct mac_vhtcapability vht_cap;
+    /* Flags giving additional information about the station */
+    u32_l flags;
+    /* Association ID of the station */
+    u16_l aid;
+    /* Bit field indicating which queues have U-APSD enabled */
+    u8_l uapsd_queues;
+    /* Maximum size, in frames, of a APSD service period */
+    u8_l max_sp_len;
+    /* Operation mode information (valid if bit @ref STA_OPMOD_NOTIF is */
+    /* set in the flags) */
+    u8_l opmode;
+    /* Index of the VIF the station is attached to */
+    u8_l vif_idx;
+#if (TDLS_ENABLE)
+    /* Whether the the station is TDLS station */
+    bool_l tdls_sta;
+#endif
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    int8_t rssi;
+    uint8_t data_rate;
+};
+
+/* Structure containing the parameters of the @ref ME_STA_ADD_CFM message */
+struct me_sta_add_cfm
+{
+    /* Station index */
+    u8_l sta_idx;
+    /* Status of the station addition */
+    u8_l status;
+    /* PM state of the station */
+    u8_l pm_state;
+};
+
+/* Structure containing the parameters of the @ref ME_STA_DEL_REQ message. */
+struct me_sta_del_req
+{
+    /* Index of the station to be deleted */
+    u8_l sta_idx;
+#if (TDLS_ENABLE)
+    /* Whether the the station is TDLS station */
+    bool_l tdls_sta;
+#endif
+};
+
+/* Structure containing the parameters of the @ref ME_TX_CREDITS_UPDATE_IND message. */
+struct me_tx_credits_update_ind
+{
+    /* Index of the station for which the credits are updated */
+    u8_l sta_idx;
+    /* TID for which the credits are updated */
+    u8_l tid;
+    /* Offset to be applied on the credit count */
+    s8_l credits;
+};
+
+/* Structure containing the parameters of the @ref ME_TRAFFIC_IND_REQ message. */
+struct me_traffic_ind_req
+{
+    /* Index of the station for which UAPSD traffic is available on host */
+    u8_l sta_idx;
+    /* Flag indicating the availability of UAPSD packets for the given STA */
+    u8_l tx_avail;
+    /* Indicate if traffic is on uapsd-enabled queues */
+    bool_l uapsd;
+};
+
+/* Structure containing the structure of a retry chain step */
+struct step
+{
+    /* Current calculated throughput */
+    u32_l tp;
+    /* Index of the sample in the rate_stats table */
+    u16_l  idx;
+};
+
+/* Structure containing the rate control statistics */
+struct rc_rate_stats
+{
+    /* Number of attempts (per sampling interval) */
+    u16_l attempts;
+    /* Number of success (per sampling interval) */
+    u16_l success;
+    /* Estimated probability of success (EWMA) */
+    u16_l probability;
+    /* Rate configuration of the sample */
+    u16_l rate_config;
+    /* Number of times the sample has been skipped (per sampling interval) */
+    u8_l sample_skipped;
+    /* Whether the old probability is available */
+    bool_l  old_prob_available;
+    /* Number of times the AMPDU has been retried with this rate */
+    u8_l n_retry;
+    /* Whether the rate can be used in the retry chain */
+    bool_l rate_allowed;
+};
+
+/* Structure containing the parameters of the @ref ME_RC_SET_RATE_REQ message. */
+struct me_rc_set_rate_req
+{
+    /* Index of the station for which the fixed rate is set */
+    u8_l sta_idx;
+    /* Rate configuration to be set */
+    u16_l fixed_rate_cfg;
+    /* Force power table update */
+    u16_l power_table_req;
+};
+
+
+/* Structure containing the parameters of @ref SM_CONNECT_REQ message. */
+struct sm_connect_req
+{
+    /* SSID to connect to */
+    struct mac_ssid ssid;
+    /* BSSID to connect to (if not specified, set this field to WILDCARD BSSID) */
+    struct mac_addr bssid;
+    /* Channel on which we have to connect (if not specified, set -1 in the chan.freq field) */
+    struct scan_chan_tag chan;
+    /* Connection flags (see @ref sm_connect_flags) */
+    u32_l flags;
+    /* Control port Ethertype */
+    u16_l ctrl_port_ethertype;
+#if 0
+    /* Length of the association request IEs */
+    u16_l ie_len;
+#endif
+    /* Listen interval to be used for this connection */
+    u16_l listen_interval;
+    /* Flag indicating if the we have to wait for the BC/MC traffic after beacon or not */
+    bool_l dont_wait_bcmc;
+    /* Authentication type */
+    u8_l auth_type;
+    /* UAPSD queues (bit0: VO, bit1: VI, bit2: BE, bit3: BK) */
+    u8_l uapsd_queues;
+    /* VIF index */
+    u8_l vif_idx;
+    /* retry counter for auth/aossoc */
+    u8_l counter_retry_auth_assoc;
+#if 0
+    /* Buffer containing the additional information elements to be put in the */
+    /* association request */
+    u32_l ie_buf[64];
+#endif
+    /* Enable embedded supplicant */
+    bool is_supplicant_enabled;
+    /* Passphrase */
+    uint8_t phrase[MAX_PSK_PASS_PHRASE_LEN];
+    uint8_t phrase_pmk[MAX_PSK_PASS_PHRASE_LEN];
+};
+
+/* Structure containing the parameters of the @ref SM_CONNECT_CFM message. */
+struct sm_connect_cfm
+{
+    /* Status. If 0, it means that the connection procedure will be performed and that */
+    /* a subsequent @ref SM_CONNECT_IND message will be forwarded once the procedure is */
+    /* completed */
+    u8_l status;
+};
+
+#define SM_ASSOC_IE_LEN   800
+/* Structure containing the parameters of the @ref SM_CONNECT_IND message. */
+struct sm_connect_ind
+{
+    /* Status code of the connection procedure */
+    u16_l status_code;
+    /* Reason code by AP */
+    u16_l reason_code;
+    /* BSSID */
+    struct mac_addr bssid;
+    /* Flag indicating if the indication refers to an internal roaming or from a host request */
+    bool_l roamed;
+    /* Index of the VIF for which the association process is complete */
+    u8_l vif_idx;
+    /* Index of the STA entry allocated for the AP */
+    u8_l ap_idx;
+    /* Index of the LMAC channel context the connection is attached to */
+    u8_l ch_idx;
+    /* Flag indicating if the AP is supporting QoS */
+    bool_l qos;
+    /* ACM bits set in the AP WMM parameter element */
+    u8_l acm;
+    /* Length of the AssocReq IEs */
+    u16_l assoc_req_ie_len;
+    /* Length of the AssocRsp IEs */
+    u16_l assoc_rsp_ie_len;
+    /* IE buffer */
+    u32_l assoc_ie_buf[SM_ASSOC_IE_LEN/4];
+
+    u16_l aid;
+    u8_l band;
+    u16_l center_freq;
+    u8_l width;
+    u32_l center_freq1;
+    u32_l center_freq2;
+
+    /* EDCA parameters */
+    u32_l ac_param[AC_MAX];
+    /* Pointer to the structure used for the diagnose module */
+    struct sm_tlv_list connect_diagnose;
+};
+
+/* Structure containing the parameters of the @ref SM_DISCONNECT_REQ message. */
+struct sm_disconnect_req
+{
+    /* Index of the VIF. */
+    u8_l vif_idx;
+};
+
+/* Structure containing the parameters of SM_ASSOCIATION_IND the message */
+struct sm_association_ind
+{
+    /* MAC ADDR of the STA */
+    struct mac_addr     me_mac_addr;
+};
+
+
+/* Structure containing the parameters of the @ref SM_DISCONNECT_IND message. */
+struct sm_disconnect_ind
+{
+    /* Status code of the disconnection procedure */
+    u16_l status_code;
+    /* Reason of the disconnection. */
+    u16_l reason_code;
+    /* Index of the VIF. */
+    u8_l vif_idx;
+    /* FT over DS is ongoing */
+    bool_l ft_over_ds;
+    /* Pointer to the structure used for the diagnose module */
+    struct sm_tlv_list connect_diagnose;
+};
+
+/* Structure containing the parameters of the @ref SM_STA_ADD_IND message. */
+struct sm_sta_add_ind
+{
+    /* Index of the VIF for which the association process is complete */
+    uint8_t vif_idx;
+    /* Index of the STA entry allocated for the AP */
+    uint8_t ap_idx;
+    /* Flag indicating if the AP is supporting QoS */
+    bool qos;
+};
+
+/* Structure containing the parameters of the @ref SM_CONNECT_ABORT_REQ message. */
+struct sm_connect_abort_req
+{
+    /* Index of the VIF. */
+    uint8_t vif_idx;
+};
+
+/* Structure containing the parameters of the @ref SM_CONNECT_ABORT_CFM message. */
+struct sm_connect_abort_cfm
+{
+    /* Status. If 0, it means that the disconnection procedure will be aborted and that */
+    /* a subsequent @ref SM_DISCONNECT_IND message will be forwarded once the procedure is */
+    /* completed. */
+    /* If 1, it means that the scan procdure will be aborted. */
+    uint8_t status;
+};
+
+/* Originally written as `static struct {...} cfg_start_req_u_tlv_t;`,
+ * which declares an unused static variable rather than a typedef.  The
+ * intent (matching neighbouring _t names) is a type alias. */
+typedef struct
+{
+    /* TASK */
+    uint32_t task;
+    /* ELEMENT */
+    uint32_t element;
+    /* length */
+    uint32_t length;
+    /* buffer */
+    uint32_t buf[];
+} cfg_start_req_u_tlv_t;
+
+struct cfg_start_req
+{
+    /* TYPE: GET/SET/RESET/DUMP */
+    uint32_t ops;
+    union {
+        /* struct for get ELEMENT */
+        struct {
+            /* TASK */
+            uint32_t task;
+            /* ELEMENT */
+            uint32_t element;
+        } get[0];
+
+        /* struct for reset ELEMENT */
+        struct {
+            /* TASK */
+            uint32_t task;
+            /* ELEMENT */
+            uint32_t element;
+        } reset[0];
+
+        /* struct for set ELEMENT with TLV based */
+        struct {
+            /* TASK */
+            uint32_t task;
+            /* ELEMENT */
+            uint32_t element;
+            /* type */
+            uint32_t type;
+            /* length */
+            uint32_t length;
+            /* buffer */
+            uint32_t buf[];
+        } set[0];
+    } u;
+};
+
+struct cfg_start_cfm
+{
+    /* Status of the AP starting procedure */
+    uint8_t status;
+};
+
+
+/* Structure containing the parameters of the @ref APM_START_REQ message. */
+struct apm_start_req
+{
+    /* Basic rate set */
+    struct mac_rateset basic_rates;
+    /* Control channel on which we have to enable the AP */
+    struct scan_chan_tag chan;
+    /* Center frequency of the first segment */
+    u32_l center_freq1;
+    /* Center frequency of the second segment (only in 80+80 configuration) */
+    u32_l center_freq2;
+    /* Width of channel */
+    u8_l ch_width;
+    /* Hidden ssid */
+    u8_l hidden_ssid;
+    /* Address, in host memory, to the beacon template */
+    u32_l bcn_addr;
+    /* Length of the beacon template */
+    u16_l bcn_len;
+    /* Offset of the TIM IE in the beacon */
+    u16_l tim_oft;
+    /* Beacon interval */
+    u16_l bcn_int;
+    /* Flags */
+    u32_l flags;
+    /* Control port Ethertype */
+    u16_l ctrl_port_ethertype;
+    /* Length of the TIM IE */
+    u8_l tim_len;
+    /* Index of the VIF for which the AP is started */
+    u8_l vif_idx;
+    /* Enable APM Embedded */
+    bool apm_emb_enabled;
+    /* rate set */
+    struct mac_rateset rate_set;
+    /* Beacon dtim period */
+    uint8_t beacon_period;
+    /* Qos is supported */
+    uint8_t qos_supported;
+    /* SSID of the AP */
+    struct mac_ssid ssid;
+    /* AP Security type */
+    uint8_t ap_sec_type;
+    /* AP Passphrase */
+    uint8_t phrase[MAX_PSK_PASS_PHRASE_LEN];
+    uint8_t phrase_tail[1];
+    /* Buf for storing IE */
+    uint8_t bcn_buf_len;
+    uint8_t bcn_buf[64];
+};
+
+/* Structure containing the parameters of the @ref APM_START_CFM message. */
+struct apm_start_cfm
+{
+    /* Status of the AP starting procedure */
+    u8_l status;
+    /* Index of the VIF for which the AP is started */
+    u8_l vif_idx;
+    /* Index of the channel context attached to the VIF */
+    u8_l ch_idx;
+    /* Index of the STA used for BC/MC traffic */
+    u8_l bcmc_idx;
+};
+
+/* Structure containing the parameters of the @ref APM_STOP_REQ message. */
+struct apm_stop_req
+{
+    /* Index of the VIF for which the AP has to be stopped */
+    u8_l vif_idx;
+};
+
+/* Structure containing the parameters of the @ref APM_CONF_MAX_STA_REQ message. */
+struct apm_conf_max_sta_req
+{
+    /* max Stattion supported */
+    u8_l max_sta_supported;
+};
+
+struct apm_sta_del_req
+{
+    /* Index of the AP VIF */
+    u8_l vif_idx;
+    /* Index of the sta in AP mode */
+    u8_l sta_idx;
+};
+
+/* Structure containing the parameters of the @ref APM_STOP_REQ message. */
+struct apm_sta_del_cfm
+{
+    /* Status of deleting sta procedure */
+    u8_l status;
+    /* Index of the AP VIF */
+    u8_l vif_idx;
+    /* Index of the sta in AP mode */
+    u8_l sta_idx;
+};
+
+/* Structure containing the parameters of the @ref APM_CHAN_SWITCH_REQ message. */
+struct apm_chan_switch_req
+{
+    /* Index of the AP VIF */
+    u8_l vif_idx;
+    /* Mode */
+    u8_l mode;
+    /* Control channel to which we have to switch */
+    struct scan_chan_tag chan;
+    /* CSA count */
+    u8_l cs_count;
+};
+
+/* Structure containing the parameters of the @ref APM_STA_ADD_IND message. */
+struct apm_sta_add_ind
+{
+    /* Flags giving additional information about the station */
+    uint32_t flags;
+    /* Station Mac address */
+    struct mac_addr sta_addr;
+    /* Index of the VIF for which the sta joined */
+    uint8_t vif_idx;
+    /* Station index */
+    uint8_t sta_idx;
+    int8_t rssi;
+    uint32_t tsflo;
+    uint32_t tsfhi;
+    uint8_t data_rate;
+};
+
+/* Structure containing the parameters of the @ref APM_STA_DEL_IND message. */
+struct apm_sta_del_ind
+{
+    /* status of the apm_sta disconnection. */
+    uint16_t status_code;
+    /* Reason of the apm_sta disconnection. */
+    uint16_t reason_code;
+    /* Station index */
+    uint8_t sta_idx;
+};
+
+/* Maximum length of the Mesh ID */
+#define MESH_MESHID_MAX_LEN     (32)
+#endif /* LMAC_MSG_H_ */

--- a/include/bouffalolab/bl60x/wifi/lmac_types.h
+++ b/include/bouffalolab/bl60x/wifi/lmac_types.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ ****************************************************************************************
+ *
+ * @file lmac_types.h
+ * Copyright (C) Bouffalo Lab 2016-2018
+ *
+ ****************************************************************************************
+ */
+
+
+#ifndef LMAC_TYPES_H_
+#define LMAC_TYPES_H_
+
+
+/**
+ ****************************************************************************************
+ * @addtogroup CO_INT
+ * @ingroup COMMON
+ * @brief Common integer standard types (removes use of stdint)
+ *
+ * @{
+ ****************************************************************************************
+ */
+
+
+/*
+ * DEFINES
+ ****************************************************************************************
+ */
+
+
+typedef uint8_t u8_l;
+typedef int8_t s8_l;
+typedef bool bool_l;
+typedef uint16_t u16_l;
+typedef int16_t s16_l;
+typedef uint32_t u32_l;
+typedef int32_t s32_l;
+typedef uint64_t u64_l;
+
+typedef uint32_t u32;
+typedef uint16_t u16;
+typedef uint8_t u8;
+
+typedef int32_t s32;
+typedef int8_t s8;
+
+typedef uint64_t __le64;
+typedef uint32_t __le32;
+typedef uint16_t __le16;
+
+typedef uint32_t __be32;
+typedef uint16_t __be16;
+
+/* @} CO_INT */
+#endif /* LMAC_TYPES_H_ */

--- a/include/bouffalolab/bl60x/wifi/reg_ipc_app.h
+++ b/include/bouffalolab/bl60x/wifi/reg_ipc_app.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef REG_IPC_APP_H_
+#define REG_IPC_APP_H_
+
+/*
+ * Application-side IPC mailbox registers of the wifi4 MAC, from the
+ * vendor bl60x_wifi_driver (reg_ipc_app.h / reg_access.h).  Offsets are
+ * relative to the IPC register block, which sits at IPC_REG_BASE_ADDR
+ * from the WiFi block base.
+ */
+
+#define IPC_REG_BASE_ADDR 0x00800000
+
+#define IPC_APP2EMB_TRIGGER_OFFSET 0x00000000
+#define IPC_APP2EMB_TRIGGER_INDEX  0x00000000
+
+#define IPC_EMB2APP_RAWSTATUS_OFFSET 0x00000004
+#define IPC_EMB2APP_RAWSTATUS_INDEX  0x00000001
+
+#define IPC_EMB2APP_ACK_OFFSET 0x00000008
+#define IPC_EMB2APP_ACK_INDEX  0x00000002
+
+#define IPC_EMB2APP_UNMASK_SET_OFFSET 0x0000000C
+#define IPC_EMB2APP_UNMASK_SET_INDEX  0x00000003
+
+#define IPC_EMB2APP_UNMASK_CLEAR_OFFSET 0x00000010
+#define IPC_EMB2APP_UNMASK_CLEAR_INDEX  0x00000004
+
+#define IPC_EMB2APP_STATUS_OFFSET 0x0000001C
+#define IPC_EMB2APP_STATUS_INDEX  0x00000007
+
+#define IPC_APP_SIGNATURE_OFFSET 0x00000040
+#define IPC_APP_SIGNATURE_INDEX  0x00000010
+
+#endif /* REG_IPC_APP_H_ */

--- a/include/bouffalolab/bl60x/wifi/supplicant_api.h
+++ b/include/bouffalolab/bl60x/wifi/supplicant_api.h
@@ -1,0 +1,263 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef SUPPLICANT_API_H_
+#define SUPPLICANT_API_H_
+
+
+#define BL_SAE_INVALID_PACKET -8
+
+/* XXX: this struct should be compatible with internal(FULLMAC) */
+typedef struct bl_wifi_timer {
+    void *_storage_0[3];
+    uint32_t exp_time;
+} bl_wifi_timer_t;
+
+/** Configuration structure for Protected Management Frame */
+typedef struct {
+    bool capable;            /**< Advertizes support for Protected Management Frame. Device will prefer to connect in PMF mode if other device also advertizes PMF capability. */
+    bool required;           /**< Advertizes that Protected Management Frame is required. Device will not associate to non-PMF capable devices. */
+} wifi_pmf_config_t;
+
+typedef enum {
+    WIFI_CIPHER_TYPE_NONE = 0,   /**< the cipher type is none */
+    WIFI_CIPHER_TYPE_WEP40,      /**< the cipher type is WEP40 */
+    WIFI_CIPHER_TYPE_WEP104,     /**< the cipher type is WEP104 */
+    WIFI_CIPHER_TYPE_TKIP,       /**< the cipher type is TKIP */
+    WIFI_CIPHER_TYPE_CCMP,       /**< the cipher type is CCMP */
+    WIFI_CIPHER_TYPE_TKIP_CCMP,  /**< the cipher type is TKIP and CCMP */
+    WIFI_CIPHER_TYPE_AES_CMAC128,/**< the cipher type is AES-CMAC-128 */
+    WIFI_CIPHER_TYPE_SMS4,       /**< the cipher type is SMS4 */
+    WIFI_CIPHER_TYPE_UNKNOWN,    /**< the cipher type is unknown */
+} wifi_cipher_type_t;
+
+typedef enum {
+    WIFI_APPIE_WPA_RSN = 0, /* WPA and/or RSN */
+    WIFI_APPIE_WPS_PR,
+    WIFI_APPIE_WPS_AR,
+    WIFI_APPIE_CUSTOM,
+    WIFI_APPIE_MAX,
+} wifi_appie_t;
+
+typedef enum wpa_alg {
+    WIFI_WPA_ALG_NONE   = 0,
+    WIFI_WPA_ALG_WEP40  = 1,
+    WIFI_WPA_ALG_TKIP   = 2,
+    WIFI_WPA_ALG_CCMP   = 3,
+    WIFI_WAPI_ALG_SMS4  = 4,
+    WIFI_WPA_ALG_WEP104 = 5,
+    WIFI_WPA_ALG_WEP    = 6,
+    WIFI_WPA_ALG_IGTK   = 7,
+    WIFI_WPA_ALG_PMK    = 8,
+    WIFI_WPA_ALG_GCMP   = 9,
+} wpa_alg_t;
+
+typedef struct {
+    int proto;
+    int pairwise_cipher;
+    int group_cipher;
+    int key_mgmt;
+    int capabilities;
+    size_t num_pmkid;
+    const uint8_t *pmkid;
+    int mgmt_group_cipher;
+} wifi_wpa_ie_t;
+
+#ifndef BIT
+#define BIT(x) (1U << (x))
+#endif
+
+#define WPA_PROTO_WPA BIT(0)
+#define WPA_PROTO_RSN BIT(1)
+
+#define WPA_KEY_MGMT_IEEE8021X BIT(0)
+#define WPA_KEY_MGMT_PSK BIT(1)
+#define WPA_KEY_MGMT_NONE BIT(2)
+#define WPA_KEY_MGMT_IEEE8021X_NO_WPA BIT(3)
+#define WPA_KEY_MGMT_WPA_NONE BIT(4)
+#define WPA_KEY_MGMT_FT_IEEE8021X BIT(5)
+#define WPA_KEY_MGMT_FT_PSK BIT(6)
+#define WPA_KEY_MGMT_IEEE8021X_SHA256 BIT(7)
+#define WPA_KEY_MGMT_PSK_SHA256 BIT(8)
+#define WPA_KEY_MGMT_WPS BIT(9)
+#define WPA_KEY_MGMT_SAE BIT(10)
+#define WPA_KEY_MGMT_FT_SAE BIT(11)
+#define WPA_KEY_MGMT_WAPI_PSK BIT(12)
+#define WPA_KEY_MGMT_WAPI_CERT BIT(13)
+#define WPA_KEY_MGMT_CCKM BIT(14)
+#define WPA_KEY_MGMT_OSEN BIT(15)
+#define WPA_KEY_MGMT_IEEE8021X_SUITE_B BIT(16)
+#define WPA_KEY_MGMT_IEEE8021X_SUITE_B_192 BIT(17)
+
+typedef enum {
+    NONE_AUTH            = 0x01,
+    WPA_AUTH_UNSPEC      = 0x02,
+    WPA_AUTH_PSK         = 0x03,
+    WPA2_AUTH_ENT        = 0x04,
+    WPA2_AUTH_PSK        = 0x05,
+    WPA_AUTH_CCKM        = 0x06,
+    WPA2_AUTH_CCKM       = 0x07,
+    WPA2_AUTH_PSK_SHA256 = 0x08,
+    WPA3_AUTH_PSK        = 0x09,
+    WPA2_AUTH_ENT_SHA256 = 0x0a,
+    WAPI_AUTH_PSK        = 0x0b,
+    WAPI_AUTH_CERT       = 0x0c,
+    WPA2_AUTH_INVALID    = 0x0d,
+} wpa_auth_mode_t;
+
+typedef enum {
+    WIFI_AUTH_OPEN = 0,         /**< authenticate mode : open */
+    WIFI_AUTH_WEP,              /**< authenticate mode : WEP */
+    WIFI_AUTH_WPA_PSK,          /**< authenticate mode : WPA_PSK */
+    WIFI_AUTH_WPA2_PSK,         /**< authenticate mode : WPA2_PSK */
+    WIFI_AUTH_WPA_WPA2_PSK,     /**< authenticate mode : WPA_WPA2_PSK */
+    WIFI_AUTH_WPA2_ENTERPRISE,  /**< authenticate mode : WPA2_ENTERPRISE */
+    WIFI_AUTH_WPA3_PSK,         /**< authenticate mode : WPA3_PSK */
+    WIFI_AUTH_WPA2_WPA3_PSK,    /**< authenticate mode : WPA2_WPA3_PSK */
+    WIFI_AUTH_WAPI_PSK,         /**< authenticate mode : WAPI_PSK */
+    WIFI_AUTH_MAX
+} wifi_auth_mode_t;
+
+struct wifi_ssid {
+    int len;
+    uint8_t ssid[32];
+};
+
+
+#define WPA_AES_KEY_LEN    16
+#define WPA_TKIP_KEY_LEN   32
+#define WPA_WEP104_KEY_LEN 13
+#define WPA_WEP40_KEY_LEN  5
+
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
+
+/* XXX order matters! */
+typedef enum {
+    SEC_PROTO_NONE,
+    SEC_PROTO_WEP_STATIC,
+    SEC_PROTO_WPA,
+    SEC_PROTO_WPA2,
+    SEC_PROTO_WPA3,
+    SEC_PROTO_WAPI,
+} sec_proto_t;
+
+typedef enum {
+    EAPOL_FRAME_4_1,
+    EAPOL_FRAME_4_2,
+    EAPOL_FRAME_4_3,
+    EAPOL_FRAME_4_4,
+    EAPOL_FRAME_2_1,
+    EAPOL_FRAME_2_2,
+} eapol_frame_id_t;
+
+typedef struct {
+    uint8_t vif_idx;
+    uint8_t sta_idx;
+    uint8_t mac[ETH_ALEN];
+    uint8_t bssid[ETH_ALEN];
+    struct wifi_ssid ssid;
+    /* sec_proto_t is 1 byte in the FW blob (compiled with -fshort-enums);
+     * use uint8_t here so Zephyr (default enum width) sees the same offset
+     * for passphrase and the chars don't shift by 2 bytes. */
+    uint8_t proto;
+    uint16_t key_mgmt;
+    uint8_t pairwise_cipher;
+    uint8_t group_cipher;
+    char passphrase[64 + 1];
+    bool pmf_required;
+    uint8_t mgmt_group_cipher; /* should always be WPA_CIPHER_AES_128_CMAC if PMFR=1 */
+    uint8_t quick_conn;
+} wifi_connect_parm_t;
+
+typedef struct {
+    uint8_t vif_idx;
+    uint8_t mac[ETH_ALEN];
+    struct wifi_ssid ssid;
+    wifi_auth_mode_t auth_mode;
+    wifi_cipher_type_t pairwise_cipher;
+    char passphrase[64 + 1];
+} wifi_ap_parm_t;
+
+struct wpa_funcs {
+    bool (*wpa_sta_init)(void);
+    bool (*wpa_sta_deinit)(void);
+    void (*wpa_sta_config)(wifi_connect_parm_t *bssid);
+    void (*wpa_sta_connect)(wifi_connect_parm_t *bssid);
+    void (*wpa_sta_disconnected_cb)(uint8_t reason_code);
+    int (*wpa_sta_rx_eapol)(uint8_t *src_addr, uint8_t *buf, uint32_t len);
+    void *(*wpa_ap_init)(wifi_ap_parm_t *parm);
+    bool (*wpa_ap_deinit)(void *data);
+    bool (*wpa_ap_join)(void **sm, uint8_t *mac, uint8_t *wpa_ie, uint8_t wpa_ie_len);
+    void (*wpa_ap_sta_associated)(void *wpa_sm, uint8_t sta_idx);
+    bool (*wpa_ap_remove)(void *sm);
+    bool (*wpa_ap_rx_eapol)(void *hapd_data, void *sm, uint8_t *data, size_t data_len);
+    int (*wpa_parse_wpa_ie)(const uint8_t *wpa_ie, size_t wpa_ie_len, wifi_wpa_ie_t *data);
+    void (*wpa_reg_diag_tlv_cb)(void *tlv_pack_cb);
+    /* XXX MIC failure countermeasure disabled for now */
+    /* int (*wpa_michael_mic_failure)(uint16_t is_unicast); */
+    uint8_t *(*wpa3_build_sae_msg)(uint8_t *bssid, uint8_t *mac, uint8_t *passphrase, uint32_t sae_msg_type, size_t *sae_msg_len);
+    int (*wpa3_parse_sae_msg)(uint8_t *buf, size_t len, uint32_t type, uint16_t status);
+    void (*wpa3_clear_sae)(void);
+};
+
+struct wps_scan_ie {
+    uint8_t    *bssid;
+    uint8_t    chan;
+    uint16_t   capinfo;
+    uint8_t    *ssid;
+    uint8_t    ssid_len;
+    uint8_t    *wpa;
+    uint8_t    *rsn;
+    uint8_t    *wps;
+};
+
+struct wps_funcs {
+    bool (*wps_parse_scan_result)(struct wps_scan_ie *scan);
+    int (*wps_sm_rx_eapol)(uint8_t *src_addr, uint8_t *buf, uint32_t len);
+    int (*wps_config)(uint8_t vif_idx, uint8_t sta_idx);
+    int (*wps_start_pending)(void);
+};
+
+typedef enum wps_status {
+    WPS_STATUS_DISABLE = 0,
+    WPS_STATUS_SCANNING,
+    WPS_STATUS_PENDING,
+    WPS_STATUS_SUCCESS,
+    WPS_STATUS_MAX,
+} wps_status_t;
+
+typedef void bl_wifi_timer_func_t(void *arg);
+typedef void(*wifi_tx_cb_t)(void *);
+
+int bl_wifi_ap_deauth_internal(uint8_t vif_idx, uint8_t sta_idx, uint32_t reason);
+bool bl_wifi_auth_done_internal(uint8_t sta_idx, uint16_t reason_code);
+void *bl_wifi_get_hostap_private_internal(void);
+void bl_wifi_timer_arm(bl_wifi_timer_t *ptimer, uint32_t time_ms, bool repeat_flag);
+void bl_wifi_timer_disarm(bl_wifi_timer_t *ptimer);
+void bl_wifi_timer_done(bl_wifi_timer_t *ptimer);
+void bl_wifi_timer_setfn(bl_wifi_timer_t *ptimer, bl_wifi_timer_func_t *pfunction, void *parg);
+int bl_wifi_set_appie_internal(uint8_t vif_idx, wifi_appie_t type, uint8_t *ie, uint16_t len, bool sta);
+int bl_wifi_unset_appie_internal(uint8_t vif_idx, wifi_appie_t type);
+bool bl_wifi_wpa_ptk_init_done_internal(uint8_t sta_idx);
+int bl_wifi_register_wpa_cb_internal(const struct wpa_funcs *cb);
+int bl_wifi_unregister_wpa_cb_internal(void);
+bool bl_wifi_skip_supp_pmkcaching(void);
+int bl_wifi_sta_update_ap_info_internal(void);
+uint8_t bl_wifi_sta_set_reset_param_internal(uint8_t reset_flag);
+bool bl_wifi_sta_is_ap_notify_completed_rsne_internal(void);
+bool bl_wifi_sta_is_running_internal(void);
+int bl_wifi_set_ap_key_internal(uint8_t vif_idx, uint8_t sta_idx, wpa_alg_t alg, int key_idx, uint8_t *key, size_t key_len, bool pairwise);
+int bl_wifi_set_sta_key_internal(uint8_t vif_idx, uint8_t sta_idx, wpa_alg_t alg, int key_idx, int set_tx, uint8_t *seq, size_t seq_len, uint8_t *key, size_t key_len, bool pairwise);
+
+int bl_wifi_set_igtk_internal(uint8_t vif_idx, uint8_t sta_idx, uint16_t key_idx, const uint8_t *pn, const uint8_t *key);
+int bl_wifi_get_sta_gtk(uint8_t vif_idx, uint8_t *out_buf, uint8_t *out_len);
+int bl_wifi_get_assoc_bssid_internal(uint8_t vif_idx, uint8_t *bssid);
+int bl_wifi_set_wps_cb_internal(const struct wps_funcs *wps_cb);
+wps_status_t bl_wifi_get_wps_status_internal(void);
+void bl_wifi_set_wps_status_internal(wps_status_t status);
+
+#endif /* SUPPLICANT_API_H_ */

--- a/include/bouffalolab/bl60x/wifi/utils_list.h
+++ b/include/bouffalolab/bl60x/wifi/utils_list.h
@@ -1,0 +1,603 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2018 Bouffalolab.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ ****************************************************************************************
+ *
+ * @file utils_list.h
+ * Copyright (C) Bouffalo Lab 2016-2018
+ *
+ ****************************************************************************************
+ */
+
+
+#ifndef UTILS_LIST_H_
+#define UTILS_LIST_H_
+
+
+struct utils_list_hdr
+{
+    struct utils_list_hdr *next;
+};
+
+struct utils_list
+{
+    /* pointer to first element of the list */
+    struct utils_list_hdr *first;
+    /* pointer to the last element */
+    struct utils_list_hdr *last;
+};
+
+
+/*
+ * FUNCTION DECLARATIONS
+ ****************************************************************************************
+ */
+/**
+ ****************************************************************************************
+ * @brief Initialize a list to defaults values.
+ * @param[in] list           Pointer to the list structure.
+ ****************************************************************************************
+ */
+void utils_list_init(struct utils_list *list);
+
+/**
+ ****************************************************************************************
+ * @brief Initialize a pool to default values, and initialize the relative free list.
+ *
+ * @param[in] list           Pointer to the list structure
+ * @param[in] pool           Pointer to the pool to be initialized
+ * @param[in] elmt_size      Size of one element of the pool
+ * @param[in] elmt_cnt       Nb of elements available in the pool
+ * @param[in] default_value  Pointer to the default value of each element (may be NULL)
+ ****************************************************************************************
+ */
+void utils_list_pool_init(struct utils_list *list, void *pool, size_t elmt_size, unsigned int elmt_cnt, void *default_value);
+
+/**
+ ****************************************************************************************
+ * @brief Add an element as last on the list.
+ *
+ * @param[in] list           Pointer to the list structure
+ * @param[in] list_hdr       Pointer to the header to add at the end of the list
+ ****************************************************************************************
+ */
+void utils_list_push_back(struct utils_list *list,
+                       struct utils_list_hdr *list_hdr);
+
+/**
+ ****************************************************************************************
+ * @brief Add an element as first on the list.
+ *
+ * @param[in] list           Pointer to the list structure
+ * @param[in] list_hdr       Pointer to the header to add at the beginning of the list
+ ****************************************************************************************
+ */
+void utils_list_push_front(struct utils_list *list, struct utils_list_hdr *list_hdr);
+/**
+ ****************************************************************************************
+ * @brief Extract the first element of the list.
+ *
+ * @param[in] list           Pointer to the list structure
+ *
+ * @return The pointer to the element extracted, and NULL if the list is empty.
+ ****************************************************************************************
+ */
+struct utils_list_hdr *utils_list_pop_front(struct utils_list *list);
+
+/**
+ ****************************************************************************************
+ * @brief Search for a given element in the list, and extract it if found.
+ *
+ * @param[in] list           Pointer to the list structure
+ * @param[in] list_hdr       Pointer to the searched element
+ *
+ * @return CO_EMPTY if the list is empty, CO_FAIL if the element not found in the list,
+ * CO_OK else.
+ ****************************************************************************************
+ */
+void utils_list_extract(struct utils_list *list, struct utils_list_hdr *list_hdr);
+
+/**
+ ****************************************************************************************
+ * @brief Searched a given element in the list.
+ *
+ * @param[in] list           Pointer to the list structure
+ * @param[in] list_hdr       Pointer to the searched element
+ *
+ * @return true if the element is found in the list, false otherwise
+ ****************************************************************************************
+ */
+int utils_list_find(struct utils_list *list, struct utils_list_hdr *list_hdr);
+
+/**
+ ****************************************************************************************
+ * @brief Insert an element in a sorted list.
+ *
+ * This primitive use a comparison function from the parameter list to select where the
+ * element must be inserted.
+ *
+ * @param[in]  list     Pointer to the list.
+ * @param[in]  element  Pointer to the element to insert.
+ * @param[in]  cmp      Comparison function (return true if first element has to be inserted
+ *                      before the second one).
+ *
+ * @return              Pointer to the element found and removed (NULL otherwise).
+ ****************************************************************************************
+ */
+void utils_list_insert(struct utils_list * const list, struct utils_list_hdr * const element,
+        int (*cmp)(struct utils_list_hdr const *elementA,
+        struct utils_list_hdr const *elementB));
+
+/**
+ ****************************************************************************************
+ * @brief Insert an element in a sorted list after the provided element.
+ *
+ * This primitive use a comparison function from the parameter list to select where the
+ * element must be inserted.
+ *
+ * @param[in]  list           Pointer to the list.
+ * @param[in]  prev_element   Pointer to the element to find in the list
+ * @param[in]  element        Pointer to the element to insert.
+ *
+ * If prev_element is not found, the provided element is not inserted
+ ****************************************************************************************
+ */
+void utils_list_insert_after(struct utils_list * const list, struct utils_list_hdr * const prev_element, struct utils_list_hdr * const element);
+
+/**
+ ****************************************************************************************
+ * @brief Insert an element in a sorted list before the provided element.
+ *
+ * This primitive use a comparison function from the parameter list to select where the
+ * element must be inserted.
+ *
+ * @param[in]  list           Pointer to the list.
+ * @param[in]  next_element   Pointer to the element to find in the list
+ * @param[in]  element        Pointer to the element to insert.
+ *
+ * If next_element is not found, the provided element is not inserted
+ ****************************************************************************************
+ */
+void utils_list_insert_before(struct utils_list * const list, struct utils_list_hdr * const next_element, struct utils_list_hdr * const element);
+
+/**
+ ****************************************************************************************
+ * @brief Concatenate two lists.
+ * The resulting list is the list passed as the first parameter. The second list is
+ * emptied.
+ *
+ * @param[in]  list1          First list (will get the result of the concatenation)
+ * @param[in]  list2          Second list (will be emptied after the concatenation)
+ ****************************************************************************************
+ */
+void utils_list_concat(struct utils_list *list1, struct utils_list *list2);
+
+/**
+ ****************************************************************************************
+ * @brief Remove the element in the list after the provided element.
+ *
+ * This primitive removes an element in the list. It is assume that element is part of
+ * the list.
+ *
+ * @param[in] list          Pointer to the list.
+ * @param[in] prev_element  Pointer to the previous element.
+ *                          NULL if @p element is the first element in the list
+ * @param[in] element       Pointer to the element to remove.
+ *
+ ****************************************************************************************
+ */
+void utils_list_remove(struct utils_list *list, struct utils_list_hdr *prev_element, struct utils_list_hdr *element);
+/**
+ ****************************************************************************************
+ * @brief Test if the list is empty.
+ *
+ * @param[in] list           Pointer to the list structure.
+ *
+ * @return true if the list is empty, false else otherwise.
+ ****************************************************************************************
+ */
+static inline int utils_list_is_empty(const struct utils_list *const list)
+{
+    return (NULL == list->first);
+}
+
+/**
+ ****************************************************************************************
+ * @brief Return the number of element of the list.
+ *
+ * @param[in] list           Pointer to the list structure.
+ *
+ * @return The number of elements in the list.
+ ****************************************************************************************
+ */
+unsigned int utils_list_cnt(const struct utils_list *const list);
+
+/**
+ ****************************************************************************************
+ * @brief Pick the first element from the list without removing it.
+ *
+ * @param[in] list           Pointer to the list structure.
+ *
+ * @return First element address. Returns NULL pointer if the list is empty.
+ ****************************************************************************************
+ */
+static inline struct utils_list_hdr *utils_list_pick(const struct utils_list *const list)
+{
+    return list->first;
+}
+
+static inline struct utils_list_hdr *utils_list_pick_last(const struct utils_list *const list)
+{
+    return list->last;
+}
+
+static inline struct utils_list_hdr *utils_list_next(const struct utils_list_hdr *const list_hdr)
+{
+    return list_hdr->next;
+}
+
+
+/*
+ * Get offset of a member variable.
+ *
+ * @param[in]   type     the type of the struct this is embedded in.
+ * @param[in]   member   the name of the variable within the struct.
+ */
+#define utils_offsetof(type, member)   ((size_t)&(((type *)0)->member))
+
+/*
+ * Get the struct for this entry.
+ *
+ * @param[in]   ptr     the list head to take the element from.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the variable within the struct.
+ */
+#define utils_container_of(ptr, type, member) \
+    ((type *) ((char *) (ptr) - utils_offsetof(type, member)))
+
+/* for double link list */
+typedef struct utils_dlist_s {
+    struct utils_dlist_s *prev;
+    struct utils_dlist_s *next;
+} utils_dlist_t;
+
+static inline void __utils_dlist_add(utils_dlist_t *node, utils_dlist_t *prev, utils_dlist_t *next)
+{
+    node->next = next;
+    node->prev = prev;
+
+    prev->next = node;
+    next->prev = node;
+}
+
+/*
+ * Get the struct for this entry.
+ *
+ * @param[in]   addr    the list head to take the element from.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the utils_dlist_t within the struct.
+ */
+#define utils_dlist_entry(addr, type, member) \
+    ((type *)((long)addr - utils_offsetof(type, member)))
+
+
+static inline void utils_dlist_add(utils_dlist_t *node, utils_dlist_t *queue)
+{
+    __utils_dlist_add(node, queue, queue->next);
+}
+
+static inline void utils_dlist_add_tail(utils_dlist_t *node, utils_dlist_t *queue)
+{
+    __utils_dlist_add(node, queue->prev, queue);
+}
+
+static inline void utils_dlist_del(utils_dlist_t *node)
+{
+    utils_dlist_t *prev = node->prev;
+    utils_dlist_t *next = node->next;
+
+    prev->next = next;
+    next->prev = prev;
+}
+
+static inline void utils_dlist_init(utils_dlist_t *node)
+{
+    node->next = node->prev = node;
+}
+
+static inline void INIT_UTILS_DLIST_HEAD(utils_dlist_t *list)
+{
+    list->next = list;
+    list->prev = list;
+}
+
+static inline int utils_dlist_empty(const utils_dlist_t *head)
+{
+    return head->next == head;
+}
+
+/*
+ * Initialise the list.
+ *
+ * @param[in]   list    the list to be inited.
+ */
+#define UTILS_DLIST_INIT(list)  {&(list), &(list)}
+
+/*
+ * Get the first element from a list
+ *
+ * @param[in]   ptr     the list head to take the element from.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the utils_dlist_t within the struct.
+ */
+#define utils_dlist_first_entry(ptr, type, member) \
+    utils_dlist_entry((ptr)->next, type, member)
+
+/*
+ * Iterate over a list.
+ *
+ * @param[in]   pos     the &struct utils_dlist_t to use as a loop cursor.
+ * @param[in]   head    he head for your list.
+ */
+#define utils_dlist_for_each(pos, head) \
+    for (pos = (head)->next; pos != (head); pos = pos->next)
+
+/*
+ * Iterate over a list safe against removal of list entry.
+ *
+ * @param[in]   pos     the &struct utils_dlist_t to use as a loop cursor.
+ * @param[in]   n       another &struct utils_dlist_t to use as temporary storage.
+ * @param[in]   head    he head for your list.
+ */
+#define utils_dlist_for_each_safe(pos, n, head) \
+    for (pos = (head)->next, n = pos->next; pos != (head); \
+    pos = n, n = pos->next)
+
+/*
+ * Iterate over list of given type.
+ *
+ * @param[in]   queue   he head for your list.
+ * @param[in]   node    the &struct utils_dlist_t to use as a loop cursor.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the utils_dlist_t within the struct.
+ */
+#define utils_dlist_for_each_entry(queue, node, type, member) \
+    for (node = utils_container_of((queue)->next, type, member); \
+         &node->member != (queue); \
+         node = utils_container_of(node->member.next, type, member))
+
+/*
+ * Iterate over list of given type safe against removal of list entry.
+ *
+ * @param[in]   queue   the head for your list.
+ * @param[in]   n       the type * to use as a temp.
+ * @param[in]   node    the type * to use as a loop cursor.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the utils_dlist_t within the struct.
+ */
+#define utils_dlist_for_each_entry_safe(queue, n, node, type, member) \
+    for (node = utils_container_of((queue)->next, type, member),  \
+         n = (queue)->next ? (queue)->next->next : NULL;        \
+         &node->member != (queue);                              \
+         node = utils_container_of(n, type, member), n = n ? n->next : NULL)
+
+/*
+ * Get the struct for this entry.
+ * @param[in]   ptr     the list head to take the element from.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the variable within the struct.
+ */
+#define utils_list_entry(ptr, type, member) \
+        utils_container_of(ptr, type, member)
+
+
+/*
+ * Iterate backwards over list of given type.
+ *
+ * @param[in]   pos     the type * to use as a loop cursor.
+ * @param[in]   head    he head for your list.
+ * @param[in]   member  the name of the utils_dlist_t within the struct.
+ * @param[in]   type    the type of the struct this is embedded in.
+ */
+#define utils_dlist_for_each_entry_reverse(pos, head, member, type) \
+    for (pos = utils_list_entry((head)->prev, type, member);        \
+         &pos->member != (head);                              \
+         pos = utils_list_entry(pos->member.prev, type, member))
+
+
+/*
+ * Get the list length.
+ *
+ * @param[in]  queue  the head for your list.
+ */
+static inline int utils_dlist_entry_number(utils_dlist_t *queue)
+{
+	int num;
+	utils_dlist_t *cur = queue;  
+	for (num=0;cur->next != queue;cur=cur->next, num++)
+		;
+	
+	return num; 
+}
+
+
+
+/*
+ * Initialise the list.
+ *
+ * @param[in]   name    the list to be initialized.
+ */
+#define UTILS_DLIST_HEAD_INIT(name) { &(name), &(name) }
+
+/*
+ * Initialise the list.
+ *
+ * @param[in]   name    the list to be initialized.
+ */
+#define UTILS_DLIST_HEAD(name) \
+        utils_dlist_t name = UTILS_DLIST_HEAD_INIT(name)
+
+/* for single link list */
+typedef struct utils_slist_s {
+    struct utils_slist_s *next;
+} utils_slist_t;
+
+static inline void utils_slist_add(utils_slist_t *node, utils_slist_t *head)
+{
+    node->next = head->next;
+    head->next = node;
+}
+
+static inline void utils_slist_add_tail(utils_slist_t *node, utils_slist_t *head)
+{
+    while (head->next) {
+        head = head->next;
+    }
+
+    utils_slist_add(node, head);
+}
+
+static inline void utils_slist_append(utils_slist_t *l, utils_slist_t *n)
+{
+    utils_slist_t *node;
+
+    node = l;
+    while (node->next) node = node->next;
+
+    /* append the node to the tail */
+    node->next = n;
+    n->next = NULL;
+}
+
+static inline void utils_slist_del(utils_slist_t *node, utils_slist_t *head)
+{
+    while (head->next) {
+        if (head->next == node) {
+            head->next = node->next;
+            break;
+        }
+
+        head = head->next;
+    }
+}
+
+static inline int utils_slist_empty(const utils_slist_t *head)
+{
+    return !head->next;
+}
+
+static inline void utils_slist_init(utils_slist_t *head)
+{
+    head->next = 0;
+}
+
+static inline utils_slist_t* utils_slist_first(utils_slist_t *l)
+{
+    return l->next;
+}
+
+static inline utils_slist_t* utils_slist_tail(utils_slist_t *l)
+{
+    while (l->next) l = l->next;
+
+    return l;
+}
+
+static inline utils_slist_t* utils_slist_next(utils_slist_t *l)
+{
+    return l->next;
+}
+
+/*
+* Iterate over list of given type.
+*
+* @param[in]   queue   he head for your list.
+* @param[in]   node    the type * to use as a loop cursor.
+* @param[in]   type    the type of the struct this is embedded in.
+* @param[in]   member  the name of the utils_slist_t within the struct.
+*/
+#define utils_slist_for_each_entry(queue, node, type, member)        \
+    for (node = utils_container_of((queue)->next, type, member); \
+         &node->member;                                        \
+         node = utils_container_of(node->member.next, type, member))
+
+/*
+ * Iterate over list of given type safe against removal of list entry.
+ *
+ * @param[in]   queue   the head for your list.
+ * @param[in]   tmp     the type * to use as a temp.
+ * @param[in]   node    the type * to use as a loop cursor.
+ * @param[in]   type    the type of the struct this is embedded in.
+ * @param[in]   member  the name of the utils_slist_t within the struct.
+ */
+#define utils_slist_for_each_entry_safe(queue, tmp, node, type, member) \
+    for (node = utils_container_of((queue)->next, type, member),    \
+         tmp = (queue)->next ? (queue)->next->next : NULL;        \
+         &node->member;                                           \
+         node = utils_container_of(tmp, type, member), tmp = tmp ? tmp->next : tmp)
+
+/*
+ * Initialise the list.
+ *
+ * @param[in]   name    the list to be initialized.
+ */
+#define UTILS_SLIST_HEAD_INIT(name) {0}
+
+/*
+ * Initialise the list.
+ *
+ * @param[in]   name    the list to be initialized.
+ */
+#define UTILS_SLIST_HEAD(name) \
+        utils_slist_t name = UTILS_SLIST_HEAD_INIT(name)
+
+/*
+ * Get the struct for this entry.
+ * @param[in]   addr     the list head to take the element from.
+ * @param[in]   type     the type of the struct this is embedded in.
+ * @param[in]   member   the name of the utils_slist_t within the struct.
+ */
+#define utils_slist_entry(addr, type, member) (                                   \
+    addr ? (type *)((long)addr - utils_offsetof(type, member)) : (type *)addr \
+)
+
+/*
+* Get the first element from a list.
+*
+* @param[in]   ptr     the list head to take the element from.
+* @param[in]   type    the type of the struct this is embedded in.
+* @param[in]   member  the name of the utils_slist_t within the struct.
+*/
+#define utils_slist_first_entry(ptr, type, member) \
+    utils_slist_entry(utils_slist_next(ptr), type, member)
+
+
+/*
+* Get the last element from a list.
+*
+* @param[in]   ptr     the list head to take the element from.
+* @param[in]   type    the type of the struct this is embedded in.
+* @param[in]   member  the name of the utils_slist_t within the struct.
+*/
+#define utils_slist_tail_entry(ptr, type, member) \
+    utils_slist_entry(utils_slist_tail(ptr), type, member)
+
+
+/*
+ * Get the list length.
+ *
+ * @param[in]   queue    the head for your list.
+ */
+static inline int utils_slist_entry_number(utils_slist_t *queue)
+{
+	int num;
+    utils_slist_t *cur = queue;  
+    for (num=0;cur->next;cur=cur->next, num++)
+		;
+	
+    return num;
+}
+#endif /* UTILS_LIST_H_ */

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -5,6 +5,15 @@ build:
   settings:
     dts_root: .
 blobs:
+# BL60x series (BL602/BL604)
+  - path: lib/bl60x/libbl602_firmware.a
+    sha256: 10d4d9e863462aebe2e7df2093b2fea03d9ebee077198bd7aff5d4eb8c019899
+    type: lib
+    version: '2.3.29'
+    url: https://github.com/bouffalolab/bouffalo_sdk/raw/v2.3.29/components/wireless/wifi4/firmware/lib/libfirmware.a
+    license-path: zephyr/blobs/license_sdk.txt
+    description: "BL602 WiFi MAC firmware (wifi4 LMAC/UMAC, scan, connect, TX/RX)"
+    doc-url: https://github.com/bouffalolab/bouffalo_sdk/tree/v2.3.29/components/wireless/wifi4
 # BL70xL series
   - path: lib/bl70xl/libbtblecontroller_bl702l_m0s1p.a
     sha256: 5e513afa94c45a1067853580f7670fc193d31b16ab27b5b8607b011e2c7cedd2


### PR DESCRIPTION
Add the BL602 (BL60x) WiFi support files from bouffalo_sdk v2.3.26:

- libbl602_firmware.a: wifi4 LMAC/UMAC MAC firmware blob, registered in module.yml with its upstream URL and SHA256.
- WiFi driver headers under include/bouffalolab/bl60x/wifi/ (lmac_msg, lmac_mac, lmac_types, ipc_shared, ipc_compat, bl60x_fw_api, supplicant_api, wifi_mgmr_ext, bflb_os_private, utils_list).

The PHY/RF library (libbl602_phyrf.a) is already provided by the BL60x BLE blob entry.